### PR TITLE
Fixing a typo in greek translation

### DIFF
--- a/News-Android-App/src/main/res/values-el/strings.xml
+++ b/News-Android-App/src/main/res/values-el/strings.xml
@@ -13,7 +13,7 @@
   <string name="tv_clickHereToOpenItem">Πατήστε εδώ για να ανοίξει το αντικείμενο</string>
   <string name="no_wifi_available">Δεν υπάρχει ασύρματη σύνδεση</string>
   <string name="do_you_want_to_download_without_wifi">Θα θέλατε να κατέβουν οι εικόνες χωρίς σύνδεση WiFi</string>
-  <string name="max_items_count_reached">Περάσατε το όριο μεγέθους των ΧΧ στοιχείων</string>
+  <string name="max_items_count_reached">Περάσατε το όριο μεγέθους των XX στοιχείων</string>
   <string name="widget_header">Νέα ownCloud</string>
   <string name="message_bar_new_articles_available">Διαθέσιμα νέα αντικείμενα</string>
   <string name="message_bar_reload">Επαναφόρτωση</string>
@@ -42,8 +42,8 @@
   <string name="action_settings">Ρυθμίσεις</string>
   <string name="action_sync_settings">Επιλογές συγχρονισμού</string>
   <string name="action_add_new_feed">Προσθήκη νέας ροής</string>
-  <string name="notification_new_items_ticker">Έχετε Χ νέα αδιάβαστα στοιχεία</string>
-  <string name="notification_new_items_text">Χ νέα αδιάβαστα στοιχεία διαθέσιμα</string>
+  <string name="notification_new_items_ticker">Έχετε X νέα αδιάβαστα στοιχεία</string>
+  <string name="notification_new_items_text">X νέα αδιάβαστα στοιχεία διαθέσιμα</string>
   <!--Strings related to login-->
   <string name="pref_title_username">Όνομα χρήστη</string>
   <string name="pref_title_password">Συνθηματικό</string>
@@ -56,7 +56,7 @@
   <string name="error_field_required">Αυτό το πεδίο είναι απαραίτητο</string>
   <string name="error_invalid_url">Αυτός ο σύνδεσμος είναι εσφαλμένος</string>
   <!--Toast Messages-->
-  <string name="toast_downloaded_x_items">Κατέβηκαν Χ παλαιά στοιχεία</string>
+  <string name="toast_downloaded_x_items">Κατέβηκαν X παλαιά στοιχεία</string>
   <string name="toast_no_more_downloads_available">Δεν υπάρχουν επιπλέον στοιχεία διαθέσιμα</string>
   <string name="pull_to_refresh_updateTags">Συγχρονισμός κατάστασης στοιχείων</string>
   <string name="pull_to_refresh_updateFolder">Συγχρονισμός φακέλου</string>


### PR DESCRIPTION
The X in the greek translation was written in greek and it was not subtitude with the actual number.
