### PR TITLE
Avoid message "Error while downloading image" upon synchronization when image caching is enabled.

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/DownloadImagesService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/DownloadImagesService.java
@@ -142,9 +142,10 @@ public class DownloadImagesService extends IntentService {
 
     private synchronized void StartNextDownloadInQueue() {
         try {
-            if(linksToImages.size() > 0)
-                new GetImageThreaded(linksToImages.get(0), imgDownloadFinished, 999, pathToImageCache, this).start();
-            linksToImages.remove(0);
+            if(linksToImages.size() > 0) {
+                String link = linksToImages.remove(0);
+                new GetImageThreaded(link, imgDownloadFinished, 999, pathToImageCache, this).start();
+            }
         } catch (Exception ex) {
             ex.printStackTrace();
             Toast.makeText(this, "Error while downloading images.", Toast.LENGTH_LONG).show();


### PR DESCRIPTION
Fix exception

> java.lang.IndexOutOfBoundsException
>   at java.util.LinkedList.remove(LinkedList.java:660)
>   at  de.luhmer.owncloudnewsreader.services.DownloadImagesService.StartNextDownloadInQueue(DownloadImagesService.java:148)
>   at de.luhmer.owncloudnewsreader.services.DownloadImagesService.onHandleIntent(DownloadImagesService.java:139)
>   at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:65)
