### PR TITLE
add support for auth via custom auth manager

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogFragment.java
@@ -92,13 +92,6 @@ public class LoginDialogFragment extends DialogFragment {
 
     final String TAG = LoginDialogFragment.class.getCanonicalName();
 
-    static LoginDialogFragment instance;
-    public static LoginDialogFragment getInstance() {
-        if(instance == null)
-            instance = new LoginDialogFragment();
-        return instance;
-    }
-
 	/**
 	 * Keep track of the login task to ensure we can cancel it if requested.
 	 */
@@ -127,12 +120,16 @@ public class LoginDialogFragment extends DialogFragment {
     private boolean mPasswordVisible = false;
     private LoginSuccessfulListener listener;
 
+    static LoginDialogFragment instance;
+    public static LoginDialogFragment getInstance() {
+        if(instance == null)
+            instance = new LoginDialogFragment();
+        return instance;
+    }
 
-	public interface LoginSuccessfulListener {
+    public interface LoginSuccessfulListener {
 		void LoginSucceeded();
 	}
-
-
 
 	public LoginDialogFragment() {
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogFragment.java
@@ -265,7 +265,7 @@ public class LoginDialogFragment extends DialogFragment {
 
                 if(isChecked) {
                     try {
-                        AccountImporter.PickNewAccount(LoginDialogFragment.this);
+                        AccountImporter.pickNewAccount(LoginDialogFragment.this);
                     } catch (NextcloudFilesAppNotInstalledException e) {
                         UiExceptionManager.showDialogForException(getActivity(), e);
                     }
@@ -540,12 +540,12 @@ public class LoginDialogFragment extends DialogFragment {
             if (requestCode == CHOOSE_ACCOUNT_SSO) {
                 importedAccount = null;
                 try {
-                    AccountImporter.RequestAuthToken(LoginDialogFragment.this, data);
+                    AccountImporter.requestAuthToken(LoginDialogFragment.this, data);
                 } catch (NextcloudFilesAppNotSupportedException e) {
                     UiExceptionManager.showDialogForException(getActivity(), e);
                 }
             } else if(requestCode == REQUEST_AUTH_TOKEN__SSO) {
-                SingleSignOnAccount singleSignOnAccount = AccountImporter.ExtractSingleSignOnAccountFromResponse(data, getActivity());
+                SingleSignOnAccount singleSignOnAccount = AccountImporter.extractSingleSignOnAccountFromResponse(data, getActivity());
                 accountAccessGranted(singleSignOnAccount);
             }
         } else if (resultCode == RESULT_CANCELED) {
@@ -553,7 +553,7 @@ public class LoginDialogFragment extends DialogFragment {
                 Toast.makeText(getActivity(), "Unknown error.. please report!", Toast.LENGTH_LONG).show();
             } else if (requestCode == REQUEST_AUTH_TOKEN__SSO) {
                 try {
-                    AccountImporter.HandleFailedAuthRequest(data);
+                    AccountImporter.handleFailedAuthRequest(data);
                 } catch (SSOException e) {
                     UiExceptionManager.showDialogForException(getActivity(), e);
                 } catch (Exception e) {


### PR DESCRIPTION
Fixes some issues related to the Android Account Manager. Uses a custom Auth-Dialog instead of the build-in authentication manager dialog.

Details: https://github.com/nextcloud/Android-SingleSignOn/issues/30