### PR TITLE
#688 - show section heading of first/general settings section in simple preferences view

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -190,10 +190,17 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 		// In the simplified UI, fragments are not used at all and we instead
 		// use the older PreferenceActivity APIs.
 
+		// This is to initialize the settings panel to allow adding a first-section header (below)
+		// without running into stupid exceptions
+		addPreferencesFromResource(R.xml.pref_empty);
+
 		// Add 'general' preferences.
+		PreferenceCategory header = new PreferenceCategory(this);
+		header.setTitle(R.string.pref_header_general);
+		getPreferenceScreen().addPreference(header);
 		addPreferencesFromResource(R.xml.pref_general);
 
-		PreferenceCategory header = new PreferenceCategory(this);
+		header = new PreferenceCategory(this);
 		header.setTitle(R.string.pref_header_display);
 		getPreferenceScreen().addPreference(header);
 		addPreferencesFromResource(R.xml.pref_display);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -191,7 +191,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 		// use the older PreferenceActivity APIs.
 
 		// This is to initialize the settings panel to allow adding a first-section header (below)
-		// without running into stupid exceptions
+		// without running into stupid exceptions (otherwise getPreferenceScreen() will return null)
 		addPreferencesFromResource(R.xml.pref_empty);
 
 		// Add 'general' preferences.

--- a/News-Android-App/src/main/res/xml/pref_empty.xml
+++ b/News-Android-App/src/main/res/xml/pref_empty.xml
@@ -1,0 +1,3 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- This layout definition is EMPTY ON PURPOSE, it's needed to initialise a settings screen to add a first-section header to -->
+</PreferenceScreen>


### PR DESCRIPTION
It is not the most beautiful fix ever, but appears to work...