### PR TITLE
#693 - fix SettingsActivity background

### DIFF
--- a/News-Android-App/src/debug/AndroidManifest.xml
+++ b/News-Android-App/src/debug/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme"
+        android:theme="@style/SplashTheme"
         android:name=".NewsReaderApplication"
         android:supportsRtl="true"
         tools:replace="android:icon, android:label, android:theme, android:name">

--- a/News-Android-App/src/main/AndroidManifest.xml
+++ b/News-Android-App/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
+        android:theme="@style/SplashTheme"
         android:usesCleartextTraffic="true"
         tools:replace="android:icon, android:label, android:theme, android:name">
         <activity

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -168,6 +168,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
             PreferenceManager.setDefaultValues(this, R.xml.pref_notification, true);
         }
 
+        setTheme(R.style.AppTheme);
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_newsreader);
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -168,8 +168,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
             PreferenceManager.setDefaultValues(this, R.xml.pref_notification, true);
         }
 
-        setTheme(R.style.AppTheme);
-		super.onCreate(savedInstanceState);
+        super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_newsreader);
 
 		ButterKnife.bind(this);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -140,16 +140,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         ThemeChooser.getInstance(this).afterOnCreate(this);
 
         setupActionBar();
-
-        // Set background accordingly to theme
-        int backgroundColor = getResources().getColor(R.color.settingsWindowBackground);
-        getWindow().getDecorView().setBackgroundColor(backgroundColor);
-
-        // Set background of category pane on tablets
-        if(isXLargeTablet(this)) {
-            backgroundColor = getResources().getColor(R.color.settingsWindowCategoryPaneBackground);
-            findViewById(android.R.id.list).setBackgroundColor(backgroundColor);
-        }
     }
 
 	@Override

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -140,6 +140,15 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         ThemeChooser.getInstance(this).afterOnCreate(this);
 
         setupActionBar();
+
+        // Set background accordingly to theme
+        int backgroundColor = getResources().getColor(R.color.settingsWindowBackground);
+        getWindow().getDecorView().setBackgroundColor(backgroundColor);
+        // Set background of category pane on tablets
+        if(isXLargeTablet(this)) {
+            backgroundColor = getResources().getColor(R.color.settingsWindowCategoryPaneBackground);
+            findViewById(android.R.id.list).setBackgroundColor(backgroundColor);
+        }
     }
 
 	@Override

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -140,15 +140,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         ThemeChooser.getInstance(this).afterOnCreate(this);
 
         setupActionBar();
-
-        // Set background accordingly to theme
-        int backgroundColor = getResources().getColor(R.color.settingsWindowBackground);
-        getWindow().getDecorView().setBackgroundColor(backgroundColor);
-        // Set background of category pane on tablets
-        if(isXLargeTablet(this)) {
-            backgroundColor = getResources().getColor(R.color.settingsWindowCategoryPaneBackground);
-            findViewById(android.R.id.list).setBackgroundColor(backgroundColor);
-        }
     }
 
 	@Override

--- a/News-Android-App/src/main/res/layout-sw600dp-land/activity_newsreader.xml
+++ b/News-Android-App/src/main/res/layout-sw600dp-land/activity_newsreader.xml
@@ -8,8 +8,7 @@
     android:gravity="bottom"
     sothree:umanoPanelHeight="68dp"
     sothree:umanoParallaxOffset="100dp"
-    sothree:umanoShadowHeight="4dp"
-    android:background="?attr/rssItemListBackground"> <!-- sothree:dragView="@+id/name" -->
+    sothree:umanoShadowHeight="4dp"> <!-- sothree:dragView="@+id/name" -->
 
         <android.support.design.widget.CoordinatorLayout
             android:id="@+id/coordinator_layout"

--- a/News-Android-App/src/main/res/layout/activity_authenticator.xml
+++ b/News-Android-App/src/main/res/layout/activity_authenticator.xml
@@ -2,8 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-	android:background="?attr/rssItemListBackground">
+    android:orientation="vertical">
     
 	<FrameLayout
 	    android:id="@+id/authenticator_content"

--- a/News-Android-App/src/main/res/layout/activity_new_feed.xml
+++ b/News-Android-App/src/main/res/layout/activity_new_feed.xml
@@ -2,8 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent"
-    android:layout_width="match_parent"
-    android:background="?attr/rssItemListBackground">
+    android:layout_width="match_parent">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/News-Android-App/src/main/res/layout/activity_news_detail.xml
+++ b/News-Android-App/src/main/res/layout/activity_news_detail.xml
@@ -2,8 +2,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
-    android:layout_width="match_parent"
-    android:background="?attr/rssItemListBackground">
+    android:layout_width="match_parent">
 
     <!-- SlidingUpPanelLayout doesn't work with layout_behavior, use marginTop -->
     <de.luhmer.owncloudnewsreader.view.PodcastSlidingUpPanelLayout

--- a/News-Android-App/src/main/res/layout/activity_newsreader.xml
+++ b/News-Android-App/src/main/res/layout/activity_newsreader.xml
@@ -8,8 +8,7 @@
     android:gravity="bottom"
     sothree:umanoPanelHeight="68dp"
     sothree:umanoParallaxOffset="100dp"
-    sothree:umanoShadowHeight="4dp"
-    android:background="?attr/rssItemListBackground"> <!-- sothree:dragView="@+id/name" -->
+    sothree:umanoShadowHeight="4dp"> <!-- sothree:dragView="@+id/name" -->
 
     <android.support.v4.widget.DrawerLayout
         android:id="@+id/drawer_layout"

--- a/News-Android-App/src/main/res/layout/activity_sync_interval_selector.xml
+++ b/News-Android-App/src/main/res/layout/activity_sync_interval_selector.xml
@@ -3,8 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="de.luhmer.owncloudnewsreader.SyncIntervalSelectorActivity"
-    tools:ignore="MergeRootFrame"
-    android:background="?attr/rssItemListBackground">
+    tools:ignore="MergeRootFrame">
 
     <include
         android:id="@+id/toolbar_layout"

--- a/News-Android-App/src/main/res/layout/fragment_dialog_feedoptions.xml
+++ b/News-Android-App/src/main/res/layout/fragment_dialog_feedoptions.xml
@@ -9,8 +9,7 @@
     android:paddingBottom="6dp"
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:background="?attr/rssItemListBackground">
+    android:paddingTop="@dimen/activity_vertical_margin">
 
     <RelativeLayout
         android:id="@+id/title_wrapper"

--- a/News-Android-App/src/main/res/layout/fragment_dialog_image.xml
+++ b/News-Android-App/src/main/res/layout/fragment_dialog_image.xml
@@ -9,8 +9,7 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     android:paddingBottom="6dp"
     android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:background="?attr/rssItemListBackground">
+    android:paddingLeft="@dimen/activity_horizontal_margin">
 
     <RelativeLayout
         android:layout_width="wrap_content"

--- a/News-Android-App/src/main/res/layout/fragment_sync_interval_selector.xml
+++ b/News-Android-App/src/main/res/layout/fragment_sync_interval_selector.xml
@@ -6,7 +6,6 @@
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:background="?attr/rssItemListBackground"
     tools:context="de.luhmer.owncloudnewsreader.SyncIntervalSelectorActivity$PlaceholderFragment">
 
 

--- a/News-Android-App/src/main/res/values-night/colors.xml
+++ b/News-Android-App/src/main/res/values-night/colors.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="app_drawer_feed_list_background_color">#383d43</color>
-    <color name="settingsWindowBackground">@color/material_grey_900</color>
-    <color name="settingsWindowCategoryPaneBackground">@color/material_grey_800</color>
 
     <color name="primaryTextColor">@android:color/white</color>
 

--- a/News-Android-App/src/main/res/values/attrs.xml
+++ b/News-Android-App/src/main/res/values/attrs.xml
@@ -3,7 +3,6 @@
 
     <attr name="dividerLineColor" format="color" />
 
-    <attr name="rssItemListBackground" format="color" />
     <attr name="starredColor" format="color" />
     <attr name="unstarredColor" format="color" />
     <attr name="starredDrawable" format="reference" />

--- a/News-Android-App/src/main/res/values/colors.xml
+++ b/News-Android-App/src/main/res/values/colors.xml
@@ -2,8 +2,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <color name="app_drawer_feed_list_background_color">#ededed</color>
-    <color name="settingsWindowBackground">@android:color/white</color>
-    <color name="settingsWindowCategoryPaneBackground">@color/material_grey_100</color>
 
     <color name="primaryTextColor">@android:color/black</color>
 
@@ -17,7 +15,7 @@
     <color name="options_menu_item_text">@color/options_menu_item</color>
 
     <color name="text_medium_emphasis">#a0000000</color>
-   
+
     <!-- see also assets/web.css -->
     <color name="news_detail_background_color">#eeeeee</color>
     <color name="news_detail_background_color_oled">#eeeeee</color>

--- a/News-Android-App/src/main/res/values/themes.xml
+++ b/News-Android-App/src/main/res/values/themes.xml
@@ -8,6 +8,8 @@
     </style>
 
     <style name="AppThemeOLED" parent="AppTheme.Base">
+        <item name="android:windowBackground">@android:color/black</item>
+
         <!-- for settings activity -->
         <item name="android:textColor">@android:color/white</item>
         <item name="android:textColorSecondary">@color/material_grey_500</item>

--- a/News-Android-App/src/main/res/values/themes.xml
+++ b/News-Android-App/src/main/res/values/themes.xml
@@ -3,6 +3,10 @@
 
     <style name="AppTheme" parent="AppTheme.Base"/>
 
+    <style name="SplashTheme" parent="AppTheme.Base">
+        <item name="android:windowBackground">@drawable/splash_screen</item>
+    </style>
+
     <style name="AppThemeOLED" parent="AppTheme.Base">
         <!-- for settings activity -->
         <item name="android:textColor">@android:color/white</item>
@@ -14,8 +18,8 @@
         <item name="primaryTextColor">@android:color/white</item>
     </style>
 
+
     <style name="AppTheme.Base" parent="Theme.AppCompat.DayNight">
-        <item name="android:windowBackground">@drawable/splash_screen</item>
 
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/News-Android-App/src/main/res/values/themes.xml
+++ b/News-Android-App/src/main/res/values/themes.xml
@@ -13,7 +13,6 @@
         <item name="android:textColorSecondary">@color/material_grey_500</item>
         <!-- for settings activity end-->
 
-        <item name="rssItemListBackground">@android:color/black</item>
         <item name="news_detail_background_color">@android:color/black</item>
         <item name="primaryTextColor">@android:color/white</item>
     </style>
@@ -31,7 +30,6 @@
         <item name="tintColor">@color/tintColor</item>
 
         <item name="dividerLineColor">#1effffff</item>
-        <item name="rssItemListBackground">@color/rss_item_list_background</item>
 
         <item name="primaryTextColor">@color/primaryTextColor</item>
 


### PR DESCRIPTION
This change does three things:
1. explicitly define a SplashScreen theme, in addition to the base AppTheme
2. use that SplashScreen theme in the app manifest
3. on creation of the main Activity, change theme to base AppTheme (= get rid of Splash background)

(4. tidy up manual color setting in SettingsActivity)
