### PR TITLE
704 - move about dialog info to settings menu

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -823,8 +823,9 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 				break;
 
 			case R.id.menu_About_Changelog:
-				DialogFragment dialog = new VersionInfoDialogFragment();
-				dialog.show(getSupportFragmentManager(), "VersionChangelogDialogFragment");
+				Toast.makeText(NewsReaderListActivity.this, "TODO: REMOVE!!!!", Toast.LENGTH_LONG).show();
+				//DialogFragment dialog = new VersionInfoDialogFragment();
+				//dialog.show(getSupportFragmentManager(), "VersionChangelogDialogFragment");
 				return true;
 
 			case R.id.menu_markAllAsRead:

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -822,12 +822,6 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 						.show();
 				break;
 
-			case R.id.menu_About_Changelog:
-				Toast.makeText(NewsReaderListActivity.this, "TODO: REMOVE!!!!", Toast.LENGTH_LONG).show();
-				//DialogFragment dialog = new VersionInfoDialogFragment();
-				//dialog.show(getSupportFragmentManager(), "VersionChangelogDialogFragment");
-				return true;
-
 			case R.id.menu_markAllAsRead:
 				NewsReaderDetailFragment ndf = getNewsReaderDetailFragment();
 				if(ndf != null) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -23,6 +23,7 @@ package de.luhmer.owncloudnewsreader;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.DialogFragment;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -45,7 +46,6 @@ import android.preference.TwoStatePreference;
 import android.provider.Settings;
 import android.support.annotation.Nullable;
 import android.support.design.widget.AppBarLayout;
-import android.support.v4.app.DialogFragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.AppCompatCheckBox;
 import android.support.v7.widget.AppCompatCheckedTextView;
@@ -139,7 +139,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 
     @Override
 	protected void onCreate(Bundle savedInstanceState) {
-		version = getVersionString();
+		version = VersionInfoDialogFragment.getVersionString(this);
         ThemeChooser.getInstance(this).chooseTheme(this);
         super.onCreate(savedInstanceState);
         ThemeChooser.getInstance(this).afterOnCreate(this);
@@ -215,13 +215,12 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         header.setTitle(R.string.pref_header_about);
         getPreferenceScreen().addPreference(header);
         addPreferencesFromResource(R.xml.pref_about);
-        Preference dialogPreference = (Preference)getPreferenceScreen().findPreference(CB_VERSION);
+        Preference dialogPreference = getPreferenceScreen().findPreference(CB_VERSION);
         dialogPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             public boolean onPreferenceClick(Preference preference) {
 				DialogFragment dialog = new VersionInfoDialogFragment();
-
-				//dialog.show(getSupportFragmentManager(), "VersionChangelogDialogFragment");
-                return true;
+				dialog.show(SettingsActivity.this.getFragmentManager(), "VersionChangelogDialogFragment");
+				return true;
             }
         });
 
@@ -389,21 +388,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                 PreferenceManager.getDefaultSharedPreferences(
                         preference.getContext()).getBoolean(preference.getKey(), false));
     }
-
-    private String getVersionString() {
-		String version = "?";
-
-		try {
-			PackageInfo pInfo = this.getPackageManager().getPackageInfo(this.getPackageName(), 0);
-			version = pInfo.versionName;
-		} catch (PackageManager.NameNotFoundException e){
-			e.printStackTrace();
-		}
-
-		Formatter formatter = new Formatter();
-		String versionString = getString(R.string.current_version);
-		return formatter.format(versionString, version).toString();
-	}
 
 	@Nullable
 	@Override

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -29,8 +29,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -62,7 +60,6 @@ import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import java.lang.reflect.Field;
-import java.util.Formatter;
 import java.util.List;
 
 import de.luhmer.owncloudnewsreader.database.DatabaseConnectionOrm;

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/VersionInfoDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/VersionInfoDialogFragment.java
@@ -21,12 +21,13 @@
 
 package de.luhmer.owncloudnewsreader;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.app.DialogFragment;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager.LayoutParams;
@@ -50,9 +51,9 @@ public class VersionInfoDialogFragment extends DialogFragment {
         LayoutInflater inflater = getActivity().getLayoutInflater();
         View view = inflater.inflate(R.layout.dialog_version_info, null);
 
-        ChangeLogFileListView clListView = (ChangeLogFileListView) view.findViewById(R.id.changelog_listview);
-        final ProgressBar progressBar = (ProgressBar) view.findViewById(R.id.changeLogLoadingProgressBar);
-        TextView versionTextView = (TextView) view.findViewById(R.id.tv_androidAppVersion);
+        ChangeLogFileListView clListView = view.findViewById(R.id.changelog_listview);
+        final ProgressBar progressBar = view.findViewById(R.id.changeLogLoadingProgressBar);
+        TextView versionTextView = view.findViewById(R.id.tv_androidAppVersion);
 
         // build dialog
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
@@ -60,7 +61,7 @@ public class VersionInfoDialogFragment extends DialogFragment {
                 .setTitle(getString(R.string.menu_About_Changelog));
 
         // set current version
-        versionTextView.setText(getVersionString());
+        versionTextView.setText(getVersionString(getActivity()));
 
         // load changelog into view
         loadChangeLog(clListView, progressBar);
@@ -82,18 +83,18 @@ public class VersionInfoDialogFragment extends DialogFragment {
 		super.onStart();
 	}
 
-    private String getVersionString() {
+    public static String getVersionString(Activity activity) {
         String version = "?";
 
         try {
-            PackageInfo pInfo = getActivity().getPackageManager().getPackageInfo(getActivity().getPackageName(), 0);
+            PackageInfo pInfo = activity.getPackageManager().getPackageInfo(activity.getPackageName(), 0);
             version = pInfo.versionName;
         } catch (PackageManager.NameNotFoundException e){
             e.printStackTrace();
         }
 
         Formatter formatter = new Formatter();
-        String versionString = getString(R.string.current_version);
+        String versionString = activity.getString(R.string.current_version);
         return formatter.format(versionString, version).toString();
     }
 
@@ -101,7 +102,7 @@ public class VersionInfoDialogFragment extends DialogFragment {
      * Loads changelog into the given view and hides progress bar when done.
      */
     private void loadChangeLog(ChangeLogFileListView clListView, final ProgressBar progressBar) {
-        new DownloadChangelogTask(getContext(), clListView, new DownloadChangelogTask.Listener() {
+        new DownloadChangelogTask(getActivity(), clListView, new DownloadChangelogTask.Listener() {
             @Override
             public void onSuccess() {
                 progressBar.setVisibility(View.GONE);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/VersionInfoDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/VersionInfoDialogFragment.java
@@ -25,6 +25,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
+import android.content.DialogInterface;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -58,6 +59,13 @@ public class VersionInfoDialogFragment extends DialogFragment {
         // build dialog
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                 .setView(view)
+                .setPositiveButton(getString(android.R.string.ok), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dismiss();
+                    }
+                })
+                .setCancelable(true) // React to click outside of version info
                 .setTitle("Changelog"); // changelog content is in english only anyways..
 
         // set current version

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/VersionInfoDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/VersionInfoDialogFragment.java
@@ -58,7 +58,7 @@ public class VersionInfoDialogFragment extends DialogFragment {
         // build dialog
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
                 .setView(view)
-                .setTitle(getString(R.string.menu_About_Changelog));
+                .setTitle("Changelog"); // changelog content is in english only anyways..
 
         // set current version
         versionTextView.setText(getVersionString(getActivity()));

--- a/News-Android-App/src/main/res/layout/dialog_version_info.xml
+++ b/News-Android-App/src/main/res/layout/dialog_version_info.xml
@@ -1,15 +1,18 @@
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical" >
+    android:orientation="vertical"
+    android:paddingBottom="16dp">
 
     <de.luhmer.owncloudnewsreader.helper.AutoResizeTextView
         android:id="@+id/tv_androidAppVersion"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="30dp"
-        android:gravity="center_horizontal|center_vertical" />
+        android:gravity="center_vertical"
+        android:paddingStart="24dp"/>
+
+    <!-- android:paddingStart="?dialogPreferredPadding" -->
 
     <ProgressBar
         android:id="@+id/changeLogLoadingProgressBar"

--- a/News-Android-App/src/main/res/layout/dialog_version_info.xml
+++ b/News-Android-App/src/main/res/layout/dialog_version_info.xml
@@ -1,8 +1,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="16dp">
+    android:orientation="vertical">
 
     <de.luhmer.owncloudnewsreader.helper.AutoResizeTextView
         android:id="@+id/tv_androidAppVersion"
@@ -10,7 +9,8 @@
         android:layout_height="wrap_content"
         android:minHeight="30dp"
         android:gravity="center_vertical"
-        android:paddingStart="24dp"/>
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"/>
 
     <!-- android:paddingStart="?dialogPreferredPadding" -->
 
@@ -25,6 +25,8 @@
         android:id="@+id/changelog_listview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scrollbars="vertical" />
+        android:scrollbars="vertical"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"/>
 
 </LinearLayout>

--- a/News-Android-App/src/main/res/menu/news_reader.xml
+++ b/News-Android-App/src/main/res/menu/news_reader.xml
@@ -61,16 +61,9 @@
         android:title="@string/action_add_new_feed"/>
 
     <item
-        android:id="@+id/menu_About_Changelog"
-        app:showAsAction="never"
-        android:orderInCategory="102"
-        android:title="@string/menu_About_Changelog"/>
-
-
-    <item
         android:id="@+id/menu_CreateDatabaseDump"
         app:showAsAction="never"
-        android:orderInCategory="103"
+        android:orderInCategory="102"
         android:title="Create Database Dump"
         android:visible="false"
         tools:ignore="HardcodedText" />

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -21,7 +21,6 @@
     <string name="title_activity_new_feed">Add new feed</string>
 
     <string name="menu_update">Refresh</string>
-    <string name="menu_About_Changelog">About / Changelog</string>
     <string name="menu_markAllAsRead">Mark all as read</string>
     <string name="menu_StartImageCaching">Download images</string>
     <string name="menu_downloadMoreItems">Download more items</string>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -176,13 +176,22 @@
     <string name="notification_downloading_podcast_title">Downloading podcast</string>
 
 
+    <!-- Settings for About -->
+    <string name="pref_header_about">About</string>
+    <string name="pref_license">License</string>
+    <string name="pref_license_summary">GNU Affero General Public License (AGPL) version 3</string>
+    <string name="pref_contribute">Contribute!</string>
+    <string name="pref_contribute_summary">Get source code</string>
+    <string name="pref_version">Nextcloud News Android app</string>
+
+
+
     <!-- Settings for Display -->
     <string name="pref_header_display">Display</string>
     <string name="pref_title_app_theme">Theme</string>
     <string name="pref_title_feed_list_layout">Feed list layout</string>
     <string name="pref_title_font_size">Font size</string>
     <string name="pref_display_browser">Browser</string>
-
 
 
 
@@ -341,9 +350,6 @@
     <string name="pref_title_CacheImagesOffline">Cache images offline</string>
     <string name="pref_title_Max_Cache_Size">Max Cache Size</string>
 
-
-
-
     <string name="pref_data_sync_image_cache_never">Never</string>
     <string name="pref_data_sync_image_cache_wifi_only">Over WiFi only</string>
     <string name="pref_data_sync_image_cache_wifi_and_mobile">Over WiFi &amp; Mobile</string>
@@ -383,8 +389,6 @@
         <item>5000</item>
         <item>10000</item>
     </string-array>
-
-
 
 
     <string name="array_sync_interval_min_5">5 Minutes</string>

--- a/News-Android-App/src/main/res/xml/pref_about.xml
+++ b/News-Android-App/src/main/res/xml/pref_about.xml
@@ -1,0 +1,30 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <Preference
+        android:key="cb_license"
+        android:title="@string/pref_license"
+        android:summary="@string/pref_license_summary">
+
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:data="https://www.gnu.org/licenses/license-list.html#AGPLv3.0" />
+    </Preference>
+
+    <Preference
+        android:key="cb_contribute"
+        android:title="@string/pref_contribute"
+        android:summary="@string/pref_contribute_summary">
+
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:data="https://github.com/nextcloud/news-android" />
+    </Preference>
+
+    <Preference
+        android:key="cb_version"
+        android:title="@string/pref_version"
+        android:summary="@string/current_version">
+    </Preference>
+
+
+</PreferenceScreen>

--- a/News-Android-App/src/main/res/xml/pref_headers.xml
+++ b/News-Android-App/src/main/res/xml/pref_headers.xml
@@ -18,6 +18,10 @@
         android:fragment="de.luhmer.owncloudnewsreader.SettingsActivity$DataSyncPreferenceFragment"
         android:title="@string/pref_header_data_sync" />
 
+    <header
+        android:fragment="de.luhmer.owncloudnewsreader.SettingsActivity$AboutPreferenceFragment"
+        android:title="@string/pref_header_about" />
+
 
     <!--
     <header


### PR DESCRIPTION
@David-Development this is a proposal about how the About/changelog thing could be addressed - this is mirroring what the Nextcloud app guys are doing:
In the settings activity, there is a new header/section for about-stuff now.

One issue: I could not yet figure out how to show a dialog when tapping on the app name/version entry - this would be a good point to pop up the changelog dialog (SettingsActivity line 222, for example).

What do you think in general?