### PR TITLE
Downgrade okhttp to 3.12.2 and use same version for all okhttp deps

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -106,6 +106,8 @@ repositories {
     maven { url  "https://dl.bintray.com/lukaville/maven" } //Needed for com.nbsp:library:1.02 in Material File Picker
 }
 
+final OKHTTP_VERSION = '3.12.2'
+
 dependencies {
     // core android studio module
     //compile project(':core')
@@ -164,8 +166,8 @@ dependencies {
 
     implementation 'com.squareup.retrofit2:retrofit:2.5.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.8.0'
+    implementation "com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}"
+    implementation "com.squareup.okhttp3:logging-interceptor:${OKHTTP_VERSION}"
 
     implementation 'com.nbsp:library:1.02' // MaterialFilePicker
 
@@ -178,14 +180,13 @@ dependencies {
     }
     testImplementation 'com.google.dexmaker:dexmaker:1.2'
     testImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.0'
+    testImplementation "com.squareup.okhttp3:mockwebserver:${OKHTTP_VERSION}"
 
 
     androidTestAnnotationProcessor "com.google.dagger:dagger-compiler:2.16"
 
-    //androidTestCompile 'com.squareup.okhttp:mockwebserver:2.5.0'
     // https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver
-    //androidTestImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.14.0'
+    //androidTestImplementation "com.squareup.okhttp3:mockwebserver:${OKHTTP_VERSION}"
 
 
     androidTestImplementation 'tools.fastlane:screengrab:1.2.0'

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ssl/OkHttpSSLClient.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ssl/OkHttpSSLClient.java
@@ -3,7 +3,6 @@ package de.luhmer.owncloudnewsreader.ssl;
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.os.Build;
-import androidx.annotation.RequiresApi;
 
 import com.google.gson.JsonParseException;
 
@@ -30,6 +29,7 @@ import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.internal.Util;
 import okhttp3.logging.HttpLoggingInterceptor;
 
 /**
@@ -38,7 +38,6 @@ import okhttp3.logging.HttpLoggingInterceptor;
 
 public class OkHttpSSLClient {
 
-    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
     public static OkHttpClient GetSslClient(HttpUrl baseUrl, String username, String password, SharedPreferences sp, MemorizingTrustManager mtm) {
         // set location of the keystore
         MemorizingTrustManager.setKeyStoreFile("private", "sslkeys.bks");
@@ -49,7 +48,7 @@ public class OkHttpSSLClient {
         OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
                 .connectTimeout(30, TimeUnit.SECONDS)
                 .readTimeout(30, TimeUnit.MINUTES)
-                .addInterceptor(new AuthorizationInterceptor(baseUrl, Credentials.basic(username, password, java.nio.charset.StandardCharsets.UTF_8)))
+                .addInterceptor(new AuthorizationInterceptor(baseUrl, Credentials.basic(username, password, Util.UTF_8)))
                 .addInterceptor(interceptor);
 
         // register MemorizingTrustManager for HTTPS


### PR DESCRIPTION
As discussed https://github.com/nextcloud/Android-SingleSignOn/commit/e781a33e0115ab8c3f4983fed2def1ab924fb9d9#commitcomment-32973039