### PR TITLE
exclude auto-value from apk to fix lint error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,9 @@ jobs:
     - run:
         name: Run unit tests
         command: ./gradlew test
+    - run:
+        name: Run Lint Tests
+        command: ./gradlew lint test
     - store_artifacts:
         path: News-Android-App/build/reports
         destination: reports

--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -150,9 +150,6 @@ dependencies {
     implementation 'com.jakewharton:butterknife:10.1.0'
     annotationProcessor 'com.jakewharton:butterknife-compiler:10.1.0'
 
-    compileOnly 'com.google.auto.value:auto-value:1.1'
-    annotationProcessor 'com.google.auto.value:auto-value:1.1'
-
     implementation 'com.sothree.slidinguppanel:library:3.2.1'
 
     implementation 'org.greenrobot:eventbus:3.1.1'
@@ -164,7 +161,10 @@ dependencies {
     //implementation 'org.apache.commons:commons-lang3:3.4'
     implementation 'com.github.gabrielemariotti.changeloglib:changelog:2.1.0'
     implementation 'org.jsoup:jsoup:1.11.3'
-    implementation ('net.rdrei.android.dirchooser:library:3.0@aar') { transitive = true }
+    implementation ('net.rdrei.android.dirchooser:library:3.0@aar') {
+        exclude group: 'com.google.auto.value', module: 'auto-value'
+        transitive = true
+    }
 
 
     implementation 'com.google.dagger:dagger:2.16'


### PR DESCRIPTION
auto-value is not used in our code and stripped by proguard anyway.

Just as a reminder: This would be the right time to enable CircleCI so we won't break any of these tests again.