### PR TITLE
Bump dagger from 2.16 to 2.22.1 and remove jsr250-api

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -118,6 +118,7 @@ repositories {
     maven { url  "https://dl.bintray.com/lukaville/maven" } //Needed for com.nbsp:library:1.02 in Material File Picker
 }
 
+final DAGGER_VERSION = '2.22.1'
 final OKHTTP_VERSION = '3.12.2'
 
 dependencies {
@@ -167,9 +168,8 @@ dependencies {
     implementation ('net.rdrei.android.dirchooser:library:3.0@aar') { transitive = true }
 
 
-    implementation 'com.google.dagger:dagger:2.16'
-    annotationProcessor "com.google.dagger:dagger-compiler:2.16"
-    compileOnly 'javax.annotation:jsr250-api:1.0'
+    implementation "com.google.dagger:dagger:${DAGGER_VERSION}"
+    annotationProcessor "com.google.dagger:dagger-compiler:${DAGGER_VERSION}"
 
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
     // Because RxAndroid releases are few and far between, it is recommended you also
@@ -196,7 +196,7 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:${OKHTTP_VERSION}"
 
 
-    androidTestAnnotationProcessor "com.google.dagger:dagger-compiler:2.16"
+    androidTestAnnotationProcessor "com.google.dagger:dagger-compiler:${DAGGER_VERSION}"
 
     // https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver
     //androidTestImplementation "com.squareup.okhttp3:mockwebserver:${OKHTTP_VERSION}"


### PR DESCRIPTION
It's included in dagger-compiler since version 2.12
https://github.com/google/dagger/commit/772374b9716e34a463a517222adbfcb678e4fb72

Signed-off-by: Unpublished <unpublished@gmx.net>