### PR TITLE
#784: Fix first entry not marked as read after sync

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -538,6 +538,9 @@ public class NewsReaderDetailFragment extends Fragment {
             loadRssItemsIntoView(rssItem);
 
             if (rssItem.size() < 10) { // Less than 10 items in the list (usually 3-5 items fit on one screen)
+                // There is no API to check, if this listener has already been added. We don't want to
+                // add it multiple times, so we take the safe route here by removing it before adding it.
+                recyclerView.removeOnItemTouchListener(itemTouchListener);
                 recyclerView.addOnItemTouchListener(itemTouchListener);
             } else {
                 recyclerView.removeOnItemTouchListener(itemTouchListener);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -534,6 +534,7 @@ public class NewsReaderDetailFragment extends Fragment {
 
         @Override
         protected void onPostExecute(List<RssItem> rssItem) {
+            previousFirstVisibleItem = -1;
             loadRssItemsIntoView(rssItem);
 
             if (rssItem.size() < 10) { // Less than 10 items in the list (usually 3-5 items fit on one screen)

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -281,6 +281,7 @@ public class NewsReaderDetailFragment extends Fragment {
     }
 
     void loadRssItemsIntoView(List<RssItem> rssItems) {
+        previousFirstVisibleItem = -1;
         try {
             NewsListRecyclerAdapter nra = ((NewsListRecyclerAdapter) recyclerView.getAdapter());
             if (nra == null) {
@@ -534,7 +535,6 @@ public class NewsReaderDetailFragment extends Fragment {
 
         @Override
         protected void onPostExecute(List<RssItem> rssItem) {
-            previousFirstVisibleItem = -1;
             loadRssItemsIntoView(rssItem);
 
             if (rssItem.size() < 10) { // Less than 10 items in the list (usually 3-5 items fit on one screen)


### PR DESCRIPTION
This PR fixes the bug described in issue #784. Can it be merged or should this be handled differently?