### PR TITLE
Short/Fast actions on bottom screen

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -27,6 +27,7 @@ import android.content.SharedPreferences;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Rect;
+import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -48,6 +49,7 @@ import android.widget.Toast;
 
 import androidx.core.content.ContextCompat;
 import androidx.core.view.GestureDetectorCompat;
+import androidx.core.widget.ImageViewCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.ItemTouchHelper;
@@ -690,7 +692,7 @@ public class NewsReaderDetailFragment extends Fragment {
 
         public FastMarkReadMotionListener(View fabMarkAllAsRead) {
             this.fabMarkAllAsRead = fabMarkAllAsRead;
-            this.circle = (ImageView) fabMarkAllAsRead.findViewById(R.id.target_done_all);
+            this.circle = (ImageView)fabMarkAllAsRead.findViewById(R.id.target_done_all);
         }
 
         @Override
@@ -726,7 +728,7 @@ public class NewsReaderDetailFragment extends Fragment {
             // Start animation of target
             circle.setImageResource(R.drawable.fa_all_read_target);
             circle.setVisibility(View.VISIBLE);
-            ((AnimatedVectorDrawableCompat)circle.getDrawable()).start();
+            ((Animatable)circle.getDrawable()).start();
         }
 
         /**
@@ -765,13 +767,13 @@ public class NewsReaderDetailFragment extends Fragment {
                 if (!markAsRead) {
                     this.markAsRead = true;
                     circle.setImageResource(R.drawable.fa_all_read_target_success);
-                    ((AnimatedVectorDrawableCompat)circle.getDrawable()).start();
+                    ((Animatable)circle.getDrawable()).start();
                 }
             } else {
                 if (this.markAsRead) {
                     this.markAsRead = false;
                     circle.setImageResource(R.drawable.fa_all_read_target);
-                    ((AnimatedVectorDrawableCompat)circle.getDrawable()).start();
+                    ((Animatable)circle.getDrawable()).start();
 
                 }
             }
@@ -786,7 +788,7 @@ public class NewsReaderDetailFragment extends Fragment {
          * @param success if all articles should be marked as read
          */
         private void stopUserInteractionProcess(View v, boolean success) {
-            ((AnimatedVectorDrawableCompat)circle.getDrawable()).stop();
+            ((Animatable)circle.getDrawable()).stop();
 
             if (this.markAsRead) {
                 Animation anim_success = AnimationUtils.loadAnimation(NewsReaderDetailFragment.this.getContext(),

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -69,6 +69,7 @@ public class SettingsActivity extends AppCompatActivity {
     public static final String LV_CACHE_IMAGES_OFFLINE_STRING = "lv_cacheImagesOffline";
 
     public static final String CB_MARK_AS_READ_WHILE_SCROLLING_STRING = "cb_MarkAsReadWhileScrolling";
+    public static final String CB_SHOW_FAST_ACTIONS = "cb_ShowFastActions";
     public static final String CB_DISABLE_HOSTNAME_VERIFICATION_STRING = "cb_DisableHostnameVerification";
     public static final String CB_SKIP_DETAILVIEW_AND_OPEN_BROWSER_DIRECTLY_STRING = "cb_openInBrowserDirectly";
     public static final String CB_SHOW_NOTIFICATION_NEW_ARTICLES_STRING = "cb_showNotificationNewArticles";

--- a/News-Android-App/src/main/res/anim/all_read_success.xml
+++ b/News-Android-App/src/main/res/anim/all_read_success.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <scale
+        android:interpolator="@android:anim/accelerate_interpolator"
+        android:fromXScale="1.0"
+        android:fromYScale="1.0"
+        android:toXScale="4.0"
+        android:toYScale="4.0"
+        android:pivotX="100%"
+        android:pivotY="0%"
+        android:duration="300" />
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0"
+        android:interpolator="@android:anim/accelerate_interpolator"
+        android:duration="300"
+        />
+</set>

--- a/News-Android-App/src/main/res/drawable/fa_all_read_target.xml
+++ b/News-Android-App/src/main/res/drawable/fa_all_read_target.xml
@@ -1,0 +1,54 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt" >
+  <aapt:attr name="android:drawable">
+    <vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="128dp"
+        android:height="128dp"
+        android:viewportWidth="128"
+        android:viewportHeight="128">
+
+      <group
+          android:name="scaleGroup"
+          android:pivotX="64"
+          android:pivotY="64"
+          android:scaleX="0.5"
+          android:scaleY="0.5"
+          >
+        <path
+            android:pathData="M64.001,64m-60,0a60,60 0,1 1,119.999 0a60,60 0,1 1,-119.999 0"
+            android:strokeWidth="6"
+            android:fillColor="#00000000"
+            android:strokeColor="#68BDEC"/>
+      </group>
+      <path
+          android:pathData="M64,64m-26.25,0a26.25,26.25 0,1 1,52.5 0a26.25,26.25 0,1 1,-52.5 0"
+          android:fillColor="#68BDEC"
+          />
+      <path
+          android:pathData="M68.969,58.656C68.603,58.291 68.012,58.291 67.647,58.656L62.359,63.944L63.681,65.266L68.969,59.969C69.325,59.612 69.325,59.013 68.969,58.656ZM72.944,58.647L63.681,67.909L60.419,64.656C60.053,64.291 59.463,64.291 59.097,64.656C58.731,65.022 58.731,65.613 59.097,65.978L63.016,69.897C63.381,70.262 63.972,70.262 64.338,69.897L74.266,59.978C74.631,59.612 74.631,59.022 74.266,58.656L74.256,58.656C73.9,58.281 73.309,58.281 72.944,58.647ZM53.8,65.988L57.719,69.906C58.084,70.272 58.675,70.272 59.041,69.906L59.697,69.25L55.122,64.656C54.756,64.291 54.166,64.291 53.8,64.656C53.434,65.022 53.434,65.622 53.8,65.988Z"
+          android:fillColor="#ffffff"
+          android:fillType="nonZero"/>
+    </vector>
+  </aapt:attr>
+
+  <target android:name="scaleGroup"> *
+    <aapt:attr name="android:animation">
+      <set>
+        <objectAnimator
+            android:duration="1000"
+            android:propertyName="scaleY"
+            android:repeatCount="infinite"
+            android:repeatMode="restart"
+            android:valueFrom="1.0"
+            android:valueTo="0.5" />
+        <objectAnimator
+            android:duration="1000"
+            android:propertyName="scaleX"
+            android:repeatCount="infinite"
+            android:repeatMode="restart"
+            android:valueFrom="1.0"
+            android:valueTo="0.5" />
+        </set>
+    </aapt:attr>
+  </target>
+</animated-vector>

--- a/News-Android-App/src/main/res/drawable/fa_all_read_target_success.xml
+++ b/News-Android-App/src/main/res/drawable/fa_all_read_target_success.xml
@@ -1,0 +1,54 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt" >
+  <aapt:attr name="android:drawable">
+    <vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="128dp"
+        android:height="128dp"
+        android:viewportWidth="128"
+        android:viewportHeight="128">
+
+      <group
+          android:name="scaleGroup"
+          android:pivotX="64"
+          android:pivotY="64"
+          android:scaleX="0.5"
+          android:scaleY="0.5"
+          >
+        <path
+            android:pathData="M64.001,64m-60,0a60,60 0,1 1,119.999 0a60,60 0,1 1,-119.999 0"
+            android:strokeWidth="6"
+            android:fillColor="#00000000"
+            android:strokeColor="#007C1F"/>
+      </group>
+      <path
+          android:pathData="M64,64m-26.25,0a26.25,26.25 0,1 1,52.5 0a26.25,26.25 0,1 1,-52.5 0"
+          android:fillColor="#007C1F"
+          />
+      <path
+          android:pathData="M68.969,58.656C68.603,58.291 68.012,58.291 67.647,58.656L62.359,63.944L63.681,65.266L68.969,59.969C69.325,59.612 69.325,59.013 68.969,58.656ZM72.944,58.647L63.681,67.909L60.419,64.656C60.053,64.291 59.463,64.291 59.097,64.656C58.731,65.022 58.731,65.613 59.097,65.978L63.016,69.897C63.381,70.262 63.972,70.262 64.338,69.897L74.266,59.978C74.631,59.612 74.631,59.022 74.266,58.656L74.256,58.656C73.9,58.281 73.309,58.281 72.944,58.647ZM53.8,65.988L57.719,69.906C58.084,70.272 58.675,70.272 59.041,69.906L59.697,69.25L55.122,64.656C54.756,64.291 54.166,64.291 53.8,64.656C53.434,65.022 53.434,65.622 53.8,65.988Z"
+          android:fillColor="#ffffff"
+          android:fillType="nonZero"/>
+    </vector>
+  </aapt:attr>
+
+  <target android:name="scaleGroup"> *
+    <aapt:attr name="android:animation">
+      <set>
+        <objectAnimator
+            android:duration="1000"
+            android:propertyName="scaleY"
+            android:repeatCount="infinite"
+            android:repeatMode="restart"
+            android:valueFrom="0.5"
+            android:valueTo="1.0" />
+        <objectAnimator
+            android:duration="1000"
+            android:propertyName="scaleX"
+            android:repeatCount="infinite"
+            android:repeatMode="restart"
+            android:valueFrom="0.5"
+            android:valueTo="1.0" />
+        </set>
+    </aapt:attr>
+  </target>
+</animated-vector>

--- a/News-Android-App/src/main/res/drawable/ic_done_all.xml
+++ b/News-Android-App/src/main/res/drawable/ic_done_all.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFF" android:pathData="M18,7l-1.41,-1.41 -6.34,6.34 1.41,1.41L18,7zM22.24,5.59L11.66,16.17 7.48,12l-1.41,1.41L11.66,19l12,-12 -1.42,-1.41zM0.41,13.41L6,19l1.41,-1.41L1.83,12 0.41,13.41z"/>
+</vector>

--- a/News-Android-App/src/main/res/layout/fragment_newsreader_detail.xml
+++ b/News-Android-App/src/main/res/layout/fragment_newsreader_detail.xml
@@ -1,4 +1,5 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -35,6 +36,41 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:indeterminate="true" />
+
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        >
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_done_all"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentEnd="true"
+            android:visibility="visible"
+            android:translationX="-16dp"
+            android:translationY="-16dp"
+            app:tint="@android:color/white"
+            app:fabSize="normal"
+            app:backgroundTint="@color/colorPrimary"
+            app:srcCompat="@drawable/ic_done_all"
+            />
+
+        <ImageView
+            android:id="@+id/target_done_all"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:translationX="18dp"
+            android:translationY="-64dp"
+            android:layout_above="@id/fab_done_all"
+            android:layout_alignParentEnd="true"
+            app:srcCompat="@drawable/fa_all_read_target"
+            android:visibility="invisible" />
+
+    </RelativeLayout>
 
 
     <!-- android:textIsSelectable="true" -->

--- a/News-Android-App/src/main/res/values-de/strings.xml
+++ b/News-Android-App/src/main/res/values-de/strings.xml
@@ -144,6 +144,7 @@
     <string name="pref_title_DisableHostnameVerification">Hostnamen-Nachweis deaktivieren</string>
     <string name="pref_title_NavigateWithVolumeButtons">Mit Lautstärketasten navigieren</string>
     <string name="pref_title_MarkAsReadWhileScrolling">Beim Bildlauf als gelesen markieren</string>
+    <string name="pref_title_ShowFastActions">Schnellzugriffe aktivieren</string>
     <string name="pref_title_OpenInBrowserDirectly">Detailansicht überspringen und Artikel in Browser öffnen</string>
 
     <string name="dialog_feature_not_available">Diese Funktion ist in dieser (Open-Source-)Version dieser App nicht verfügbar. Wenn Sie diese Funktion nutzen möchten, laden Sie bitte die App aus dem GitHub-Repository oder aus dem Google Play Store herunter.</string>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
     <string name="pref_title_DisableHostnameVerification">Disable Hostname Verification</string>
     <string name="pref_title_NavigateWithVolumeButtons">Navigate with volume buttons</string>
     <string name="pref_title_MarkAsReadWhileScrolling">Mark as read while scrolling</string>
+    <string name="pref_title_ShowFastActions">Activate fast access functions</string>
     <string name="pref_title_OpenInBrowserDirectly">Skip detailed view and open article in the browser</string>
 
     <string name="dialog_feature_not_available">This feature is not available in this (open-source) version of this app. If you want to use this feature please download the app from the GitHub Repository or download the App from the Google Play Store.</string>

--- a/News-Android-App/src/main/res/xml/pref_general.xml
+++ b/News-Android-App/src/main/res/xml/pref_general.xml
@@ -79,6 +79,11 @@
             app:iconSpaceReserved="false"/>
 
         <SwitchPreference
+            android:key="cb_ShowFastActions"
+            android:title="@string/pref_title_ShowFastActions"
+            app:iconSpaceReserved="false"/>
+
+        <SwitchPreference
             android:key="cb_openInBrowserDirectly"
             android:title="@string/pref_title_OpenInBrowserDirectly"
             app:iconSpaceReserved="false"/>


### PR DESCRIPTION
What it does:
- It adds an option to settings to activate "Fast Actions"
- After that, a FAB is shown on the NewsReaderDetailFragment to fast-mark all items as read (for now only function)
- A move gesture is required to prevent accidentially marking all items as read

Demo video: https://drive.google.com/file/d/1dwYcCa0q7WeB-wY7HxsNYwhKLGNrmz6a/view

It accomodates growing screen sizes and more interaction within direct reach of the users hand. Fast actions were a feature of gReader which I used a lot when screening news feeds. More functions could follow.