### PR TITLE
update gradle / add debug information to github issue

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -94,6 +94,7 @@ public class SettingsActivity extends AppCompatActivity {
     public static final String SP_SWIPE_LEFT_ACTION_DEFAULT = "2";
 
     public static final String CB_VERSION = "cb_version";
+    public static final String CB_REPORT_ISSUE = "cb_reportIssue";
 
     protected @Inject SharedPreferences mPrefs;
 

--- a/News-Android-App/src/main/res/xml/pref_about.xml
+++ b/News-Android-App/src/main/res/xml/pref_about.xml
@@ -22,9 +22,11 @@
             android:summary="@string/pref_report_issue_summary"
             app:iconSpaceReserved="false">
 
+            <!--
             <intent
                 android:action="android.intent.action.VIEW"
                 android:data="https://github.com/nextcloud/news-android/issues" />
+            -->
         </Preference>
 
         <Preference

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 


### PR DESCRIPTION
Adds debug information before opening the GitHub website. It'll automatically fill out the bug report with additional information such as app version and app settings. Therefore it makes debugging for us easier. 

@stefan-niedermann @desperateCoder maybe this is helpful for you as well?


The following example shows which settings I include in bug reports for the news app. 

```
Please describe your bug here...

---

App Version: 0.9.9.30
App Version Code: 146

---

SSO enabled: true

---

OS Version: 4.14.112+(5891938)
OS API Level: 29
Device: generic_x86
Model (and Product): Android SDK built for x86 (sdk_gphone_x86)

---

sp_max_cache_size=500
sp_swipe_left_action=2
sw_use_single_sign_on=true
cb_ShowOnlyUnread=false
cb_openInBrowserDirectly=false
lv_cacheImagesOffline=0
cb_AutoSyncOnStart=false
sp_news_detail_actionbar_icons=[]
sp_swipe_right_action=1
cb_NavigateWithVolumeButtons=false
sp_font_size=1.0
NewsWebVersionNumber=13.1.6
sp_search_in=0
cb_showNotificationNewArticles=true
sp_sort_order=1
cb_MarkAsReadWhileScrolling=false
sp_feed_list_layout=0
cb_oled_mode=false
sp_display_browser=0
sp_app_theme=0

```