### PR TITLE
Android actions ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: app-dev-debug
-          path: app/build/outputs/apk/dev/debug/app-dev-debug.apk
+          path: app/build/outputs/apk/dev/debug/News-Android-App-dev-debug.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: app-dev-debug
-          path: app/build/outputs/apk/dev/debug/News-Android-App-dev-debug.apk
+          path: News-Android-App/build/outputs/apk/dev/debug/News-Android-App-dev-debug.apk

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,10 +1,41 @@
-name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+name: Android CI
 
+on: [push, pull_request]
 jobs:
   validation:
-    name: "Validation"
+    name: Validate Gradle Wrapper
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1
+
+  test:
+    name: Run Unit Tests
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Unit tests
+        run: bash ./gradlew test --stacktrace
+
+  apk:
+    name: Generate APK
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build debug APK
+        run: bash ./gradlew assembleDev --stacktrace
+      - name: Upload APK
+        uses: actions/upload-artifact@v1
+        with:
+          name: app-dev-debug
+          path: app/build/outputs/apk/dev/debug/app-dev-debug.apk

--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -68,6 +68,11 @@ android {
         extra {
             dimension "default"
         }
+        // Used for continous integration, e.g. to test built .apk-files from pull requests
+        dev {
+            dimension "default"
+            applicationIdSuffix ".dev"
+        }
     }
 
     lintOptions {

--- a/News-Android-App/src/dev/res/drawable/ic_launcher_foreground.xml
+++ b/News-Android-App/src/dev/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="872.78925"
+    android:viewportHeight="872.78925">
+    <group
+        android:translateX="21.81973"
+        android:translateY="21.81973">
+        <group
+            android:translateX="20.728745"
+            android:translateY="20.728745">
+            <group
+                android:translateX="137.84616"
+                android:translateY="137.84616">
+                <path
+                    android:fillColor="#ffffff"
+                    android:pathData="M100.929,89C94.32,89 89,94.32 89,100.929v23.857c0,6.608 5.32,11.929 11.929,11.929h310.143c6.608,0 11.929,-5.32 11.929,-11.929L423,100.929C423,94.32 417.68,89 411.071,89L100.929,89zM100.929,184.429C94.32,184.429 89,189.749 89,196.357v23.857c0,6.608 5.32,11.929 11.929,11.929h214.714c6.608,0 11.929,-5.32 11.929,-11.929v-23.857c0,-6.608 -5.32,-11.929 -11.929,-11.929L100.929,184.429zM100.929,279.857C94.32,279.857 89,285.177 89,291.786v23.857c0,6.608 5.32,11.929 11.929,11.929h286.286c6.608,0 11.929,-5.32 11.929,-11.929v-23.857c0,-6.608 -5.32,-11.929 -11.929,-11.929L100.929,279.857zM100.929,375.286C94.32,375.286 89,380.606 89,387.214v23.857C89,417.68 94.32,423 100.929,423L244.071,423C250.68,423 256,417.68 256,411.071v-23.857c0,-6.608 -5.32,-11.929 -11.929,-11.929L100.929,375.286z" />
+            </group>
+        </group>
+    </group>
+    <group
+        android:scaleX="2.6"
+        android:scaleY="3"
+        android:translateX="440"
+        android:translateY="520">
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M11.908125 40h11.4c4.44 0 7.24 -1.04 9.2 -3.4 2.32 -2.72 3.56 -6.68 3.56 -11.2 0 -4.48 -1.24 -8.44 -3.56 -11.2 -1.96 -2.36 -4.72 -3.36 -9.2 -3.36h-11.4zm6 -5V15.84h5.4c4.52 0 6.76 3.16 6.76 9.6 0 6.4 -2.24 9.56 -6.76 9.56z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M46.894375 27.44h13.96v-5h-13.96v-6.6h15.08v-5h-21.08V40h21.8v-5h-15.8z" />
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M80.333125 40l10 -29.16h-6.04l-6.36 21.96 -6.48 -21.96h-6.04l9.84 29.16z" />
+    </group>
+</vector>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Nextcloud News Reader – Android App
 ==================================
 
+[![Android CI](https://github.com/nextcloud/news-android/workflows/Android%20CI/badge.svg)](https://github.com/nextcloud/news-android/actions)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2bb65782750445c99e80dab29f6701a6)](https://www.codacy.com/app/Nextcloud/news-android?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nextcloud/news-android&amp;utm_campaign=Badge_Grade)
-[![CircleCI](https://circleci.com/gh/nextcloud/news-android/tree/master.svg?style=svg)](https://circleci.com/gh/nextcloud/news-android/tree/master)
 
 The Nextcloud News Reader Android App is under [AGPLv3](https://www.gnu.org/licenses/license-list.html#AGPLv3.0) License terms.
 


### PR DESCRIPTION
This PR enables a CI-build for the News android app.

@David-Development your choice whether or not you want to go this way, but i have made positive experiences only while i migrated Notes and Deck to GitHub Actions.

- Better integration without leaving the GitHub UI
- Much better performance
- You can access a dev-build artifact for each build (and install it beside a released version)
- Everyone who forks this project on GitHub has automatically CI without the need to configure a 3rd-party service

Interested?
