### PR TITLE
Fix issues on API Level 21

### DIFF
--- a/News-Android-App/src/main/res/drawable/custom_progress.xml
+++ b/News-Android-App/src/main/res/drawable/custom_progress.xml
@@ -19,6 +19,7 @@
             <shape
                 android:innerRadiusRatio="2.3"
                 android:shape="ring"
+                android:useLevel="true"
                 android:angle="0"
                 android:type="sweep"
                 android:thicknessRatio="15.0">


### PR DESCRIPTION
Hi,

I found there is a compatibility issue in the progress bar.

According to [this discussion](https://stackoverflow.com/questions/26532382/progressbar-circle-shows-no-progress-on-android-l-api-21), the default value for android:useLevel under the tag incorrectly changed to false in the L Preview build. Therefore you should add **android:useLevel="true"** in the shape element.

Here is the behavior between API 21 and 27.

API 27
<img width="47" alt="image" src="https://user-images.githubusercontent.com/62385383/83586102-39a81300-a57e-11ea-8a70-3631685345b8.png">

API 21
<img width="67" alt="image" src="https://user-images.githubusercontent.com/62385383/83586127-4462a800-a57e-11ea-946a-145a25514047.png">
 
Note that the progress bar will always be full no matter what the progress value set to it.

This pull request help you fix this problem, thanks for your attention.