### PR TITLE
Custom Tabs when skipping detailed view

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -74,7 +74,9 @@ import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
+import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import androidx.core.view.GravityCompat;
 import androidx.customview.widget.ViewDragHelper;
 import androidx.drawerlayout.widget.DrawerLayout;
@@ -1054,8 +1056,21 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 		if (mPrefs.getBoolean(SettingsActivity.CB_SKIP_DETAILVIEW_AND_OPEN_BROWSER_DIRECTLY_STRING, false)) {
             String currentUrl = vh.getRssItem().getLink();
 
-            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(currentUrl));
-            startActivity(browserIntent);
+            //Choose Browser based on user settings
+			//modified copy from NewsDetailFragment.java:loadUrl(String url)
+			int selectedBrowser = Integer.parseInt(mPrefs.getString(SettingsActivity.SP_DISPLAY_BROWSER, "0"));
+			if (selectedBrowser == 0) { // Custom Tabs
+				CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder()
+						.setToolbarColor(ContextCompat.getColor(this, R.color.colorPrimary))
+						.setShowTitle(true)
+						.setStartAnimations(this, R.anim.slide_in_right, R.anim.slide_out_left)
+						.setExitAnimations(this, R.anim.slide_in_left, R.anim.slide_out_right)
+						.addDefaultShareMenuItem();
+				builder.build().launchUrl(this, Uri.parse(currentUrl));
+			} else { //External browser
+				Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(currentUrl));
+				startActivity(browserIntent);
+			}
 
             ((NewsListRecyclerAdapter) getNewsReaderDetailFragment().getRecyclerView().getAdapter()).changeReadStateOfItem(vh, true);
 		} else {


### PR DESCRIPTION
I noticed that regardless of the browser preferences (built-in, Custom Tabs or external) when skipping the detail view, the external browser is always used.
Therefore I copied the preference check from the detail view fragment to the list activity to open the custom tabs when they are selected in the  preferences (I stripped out the built-in browser because it only works inside the detail view)