### PR TITLE
Enable core library desugaring

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -26,6 +26,8 @@ android {
         testInstrumentationRunnerArguments clearPackageData: 'true'
 
         vectorDrawables.useSupportLibrary = true
+
+        multiDexEnabled true
     }
 
     testOptions {
@@ -35,6 +37,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
     }
 
     buildTypes {
@@ -188,6 +191,9 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:${OKHTTP_VERSION}"
 
     implementation 'com.nbsp:library:1.8' // MaterialFilePicker
+
+    implementation 'androidx.multidex:multidex:2.0.1'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.1'
 
     //extraImplementation 'com.github.tommus:youtube-android-player-api:1.2.2'
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderApplication.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderApplication.java
@@ -1,6 +1,6 @@
 package de.luhmer.owncloudnewsreader;
 
-import android.app.Application;
+import androidx.multidex.MultiDexApplication;
 
 import de.luhmer.owncloudnewsreader.di.ApiModule;
 import de.luhmer.owncloudnewsreader.di.AppComponent;
@@ -8,7 +8,7 @@ import de.luhmer.owncloudnewsreader.di.DaggerAppComponent;
 import de.luhmer.owncloudnewsreader.helper.AdBlocker;
 import de.luhmer.owncloudnewsreader.helper.ForegroundListener;
 
-public class NewsReaderApplication extends Application {
+public class NewsReaderApplication extends MultiDexApplication {
 
     protected AppComponent mAppComponent;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-ANDROID_BUILD_MIN_SDK_VERSION=17
+ANDROID_BUILD_MIN_SDK_VERSION=18
 ANDROID_BUILD_TARGET_SDK_VERSION=29
 ANDROID_BUILD_SDK_VERSION=29
 android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 04 19:59:05 CET 2020
+#Sun Dec 27 15:28:12 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
:warning: This PR also raises the `minSdk` from `17` to `18`. This shouldn't be an issue because the Files app has already `minSdk = 19`.

This enables the following features fully backward compatible:

- Sequential streams (java.util.stream)
- A subset of java.time
- java.util.function
- Recent additions to java.util.{Map,Collection,Comparator}
- Optionals (java.util.Optional, java.util.OptionalInt and java.util.OptionalDouble) and some other new classes useful with the above APIs
- Some additions to java.util.concurrent.atomic (new methods on AtomicInteger, AtomicLong and AtomicReference)
- ConcurrentHashMap (with bug fixes for Android 5.0)

Fore more information see https://developer.android.com/studio/write/java8-support