### PR TITLE
Use neutral grey for sidebar background in dark mode

### DIFF
--- a/News-Android-App/src/main/res/values-night/colors.xml
+++ b/News-Android-App/src/main/res/values-night/colors.xml
@@ -18,7 +18,6 @@
     <color name="news_detail_background_color_oled">@android:color/black</color>
 
     <color name="owncloudBlue">#1D2D44</color>
-    <color name="nextcloudBlue">#006AA3</color>
 
     <color name="text_medium_emphasis">#a0ffffff</color>
 

--- a/News-Android-App/src/main/res/values-night/colors.xml
+++ b/News-Android-App/src/main/res/values-night/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="app_drawer_feed_list_background_color">#383d43</color>
+    <color name="app_drawer_feed_list_background_color">#212121</color>
 
     <color name="primaryTextColor">@android:color/white</color>
 


### PR DESCRIPTION
## :question: What?

- Use a more neutral grey for the sidebar
- Remove customized dark flavor of the "Nextcloud blue" (won't matter anyway after https://github.com/nextcloud/news-android/issues/642 has been implemented)

## :eyes: Screenshots

1. old (current `master`)
2. new (changes from this PR)
3. files app for comparison 

1 | 2 | 3
--- | --- | ---
![grafik](https://user-images.githubusercontent.com/4741199/116993602-fdbe8600-acd7-11eb-9ddf-897e17031506.png) | ![grafik](https://user-images.githubusercontent.com/4741199/116994024-80dfdc00-acd8-11eb-8f0f-b044203966b2.png) | ![grafik](https://user-images.githubusercontent.com/4741199/116993653-1169ec80-acd8-11eb-9d1e-394ec9132640.png)
