### PR TITLE
Use native system file picker for OPML import

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -120,7 +120,6 @@ repositories {
     jcenter()
     maven { url "https://jitpack.io" }
     maven { url 'https://guardian.github.io/maven/repo-releases' } //needed for com.gu:option:1.3 in Android-DirectoryChooser
-    maven { url  "https://dl.bintray.com/lukaville/maven" } //Needed for com.nbsp:library:1.8 in Material File Picker
 }
 
 final DAGGER_VERSION = '2.33'
@@ -185,8 +184,6 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-gson:$RETROFIT_VERSION"
     implementation "com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}"
     implementation "com.squareup.okhttp3:logging-interceptor:${OKHTTP_VERSION}"
-
-    implementation 'com.nbsp:library:1.8' // MaterialFilePicker
 
     implementation 'androidx.multidex:multidex:2.0.1'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
@@ -163,8 +163,7 @@ public class NewFeedActivity extends AppCompatActivity {
 
     private void openFilePicker() {
         startActivityForResult(new Intent(Intent.ACTION_GET_CONTENT)
-                .addCategory(Intent.CATEGORY_OPENABLE)
-                .setType("text/*"), REQUEST_CODE_OPML_IMPORT);
+                .addCategory(Intent.CATEGORY_OPENABLE).setType("*/*"), REQUEST_CODE_OPML_IMPORT);
     }
 
     public void exportOpml() {
@@ -219,12 +218,12 @@ public class NewFeedActivity extends AppCompatActivity {
                 case ContentResolver.SCHEME_CONTENT:
                 case ContentResolver.SCHEME_FILE:
                     new Thread(() -> {
-                        try {
-                            final File cacheFile = new File(getCacheDir().getAbsolutePath() + "/import.opml");
-                            final FileOutputStream outputStream = new FileOutputStream(cacheFile);
-                            byte[] buffer = new byte[4096];
-                            final InputStream inputStream = getContentResolver().openInputStream(importUri);
-
+                        final File cacheFile = new File(getCacheDir().getAbsolutePath() + "/import.opml");
+                        byte[] buffer = new byte[4096];
+                        try (
+                                final InputStream inputStream = getContentResolver().openInputStream(importUri);
+                                final FileOutputStream outputStream = new FileOutputStream(cacheFile)
+                        ) {
                             int count;
                             while ((count = inputStream.read(buffer)) > 0) {
                                 outputStream.write(buffer, 0, count);

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -421,6 +421,8 @@
     <string name="array_sync_interval_hour_12">12 Hours</string>
     <string name="array_sync_interval_hour_24">24 Hours</string>
     <string name="switch_account">Switch account</string>
+    <string name="parsing_opml">Parsing OPML…</string>
+    <string name="please_wait">Please wait.</string>
 
     <string-array name="array_sync_interval" translatable="false">
         <item>@string/array_sync_interval_min_0</item>


### PR DESCRIPTION
While working on #952 i realized that the used `MaterialFilePicker` and its forks aren't maintained well and don't work flawlessly in version `1.9.1+`.

I therefore suggest to remove this dependency completely and use the native system file picker for selecting an `.opml` file.

Another advantage is that starting with `targetSdk=30` the current implementation will probably break anyway because of the introduction of [scoped storage](https://developer.android.com/about/versions/11/privacy/storage).

Last but not least the native system file picker solution will allow to directly pick files from document providers like Nextcloud without the need of having the file available offline on the device.