### PR TITLE
Remove multidex

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -26,8 +26,6 @@ android {
         testInstrumentationRunnerArguments clearPackageData: 'true'
 
         vectorDrawables.useSupportLibrary = true
-
-        multiDexEnabled true
     }
 
     buildFeatures {
@@ -188,7 +186,6 @@ dependencies {
 
     implementation 'com.nbsp:library:1.8' // MaterialFilePicker
 
-    implementation 'androidx.multidex:multidex:2.0.1'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
     testImplementation 'junit:junit:4.13.2'

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderApplication.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderApplication.java
@@ -1,6 +1,6 @@
 package de.luhmer.owncloudnewsreader;
 
-import androidx.multidex.MultiDexApplication;
+import android.app.Application;
 
 import de.luhmer.owncloudnewsreader.di.ApiModule;
 import de.luhmer.owncloudnewsreader.di.AppComponent;
@@ -8,7 +8,7 @@ import de.luhmer.owncloudnewsreader.di.DaggerAppComponent;
 import de.luhmer.owncloudnewsreader.helper.AdBlocker;
 import de.luhmer.owncloudnewsreader.helper.ForegroundListener;
 
-public class NewsReaderApplication extends MultiDexApplication {
+public class NewsReaderApplication extends Application {
 
     protected AppComponent mAppComponent;
 


### PR DESCRIPTION
After [raising the `minSdk` to `21`](https://github.com/nextcloud/news-android/pull/951), it is no longer necessary to include `multidex` support explicitly.

Starting with Android 5, it is supported out of the box → Removing it will reduce the size of the compiled app and reduce the compile time.