### PR TITLE
Enhance empty content view

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -285,7 +285,7 @@ public class NewsReaderDetailFragment extends Fragment {
 
         Runnable myRunnable = () -> {
             binding.pbLoading.setVisibility(View.VISIBLE);
-            binding.tvNoItemsAvailable.setVisibility(View.GONE);
+            binding.tvNoItemsAvailable.getRoot().setVisibility(View.GONE);
         };
         mainHandler.post(myRunnable);
 
@@ -304,9 +304,9 @@ public class NewsReaderDetailFragment extends Fragment {
 
             binding.pbLoading.setVisibility(View.GONE);
             if (nra.getItemCount() <= 0) {
-                binding.tvNoItemsAvailable.setVisibility(View.VISIBLE);
+                binding.tvNoItemsAvailable.getRoot().setVisibility(View.VISIBLE);
             } else {
-                binding.tvNoItemsAvailable.setVisibility(View.GONE);
+                binding.tvNoItemsAvailable.getRoot().setVisibility(View.GONE);
             }
 
             binding.list.scrollToPosition(0);
@@ -499,7 +499,7 @@ public class NewsReaderDetailFragment extends Fragment {
         @Override
         protected void onPreExecute() {
             binding.pbLoading.setVisibility(View.VISIBLE);
-            binding.tvNoItemsAvailable.setVisibility(View.GONE);
+            binding.tvNoItemsAvailable.getRoot().setVisibility(View.GONE);
             super.onPreExecute();
         }
 

--- a/News-Android-App/src/main/res/layout/empty_content_view.xml
+++ b/News-Android-App/src/main/res/layout/empty_content_view.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="@dimen/spacer_2x"
+    android:visibility="gone"
+    tools:background="?attr/colorPrimary"
+    tools:visibility="visible">
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="match_parent"
+        android:layout_height="72dp"
+        android:layout_above="@+id/title"
+        android:layout_gravity="center"
+        android:contentDescription="@null"
+        app:srcCompat="@drawable/ic_launcher_foreground_full"
+        app:tint="@color/empty_content_view_logo" />
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:gravity="center"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp"
+        android:text="@string/empty_view_content"
+        android:textAlignment="center"
+        android:textSize="@dimen/empty_content_font_size" />
+
+    <TextView
+        android:id="@+id/description"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/title"
+        android:layout_centerHorizontal="true"
+        android:paddingStart="@dimen/spacer_2x"
+        android:paddingEnd="@dimen/spacer_2x"
+        android:text="@string/empty_view_content_action"
+        android:textAlignment="center" />
+</RelativeLayout>

--- a/News-Android-App/src/main/res/layout/fragment_newsreader_detail.xml
+++ b/News-Android-App/src/main/res/layout/fragment_newsreader_detail.xml
@@ -20,14 +20,9 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <TextView
+    <include
         android:id="@+id/tv_no_items_available"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center_vertical|center_horizontal"
-        android:text="@string/empty_view_content"
-        android:visibility="gone"
-        android:textSize="18sp" />
+        layout="@layout/empty_content_view" />
 
     <ProgressBar
         android:id="@+id/pb_loading"

--- a/News-Android-App/src/main/res/values-night/colors.xml
+++ b/News-Android-App/src/main/res/values-night/colors.xml
@@ -7,6 +7,7 @@
     <color name="divider_row_color">#292929</color>
 
     <color name="options_menu_item_text">@color/options_menu_item_night</color>
+    <color name="empty_content_view_logo">#666</color>
 
     <!-- Color of slide up panel -->
     <color name="slide_up_panel_background_color">#ff343434</color>

--- a/News-Android-App/src/main/res/values/colors.xml
+++ b/News-Android-App/src/main/res/values/colors.xml
@@ -30,6 +30,7 @@
     <color name="markasreadColor">@android:color/holo_green_light</color>
     <color name="swipeBackground">#aaa</color>
     <color name="menuSeparator">#aaa</color>
+    <color name="empty_content_view_logo">#999</color>
 
     <color name="tintColor">@android:color/black</color>
 

--- a/News-Android-App/src/main/res/values/dimens.xml
+++ b/News-Android-App/src/main/res/values/dimens.xml
@@ -19,6 +19,8 @@
 
     <dimen name="podcast_media_control_height">80dp</dimen>
 
+    <dimen name="empty_content_font_size">26sp</dimen>
+
     <dimen name="spacer_1hx">4dp</dimen>
     <dimen name="spacer_1x">8dp</dimen>
     <dimen name="spacer_2x">16dp</dimen>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="title_activity_sync_interval_selector">Sync Interval</string>
     <string name="title_activity_news_detail">NewsDetailActivity</string>
     <string name="empty_view_content">No items here</string>
+    <string name="empty_view_content_action">Pull down to refresh</string>
     <string name="toast_GettingMoreItems">Download of more items started… Please wait.</string>
     <string name="no_wifi_available">No WiFi connected</string>
     <string name="do_you_want_to_download_without_wifi">Do you want to download the images without a Wi-Fi connection</string>


### PR DESCRIPTION
Fixes #824

# ❔ What

- Adds logo
- Uses bigger font size
- Adds call to action text ("pull down 2 refresh") 
- Aligns this view with Deck & Notes

# :eyes: Before & after screenshots:

| _ | _ |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/4741199/122589320-65e6e280-d060-11eb-9dfc-55d96f67878f.png) | ![after](https://user-images.githubusercontent.com/4741199/122589336-6b442d00-d060-11eb-98e3-d33279dbdf01.png) |

Signed-off-by: Stefan Niedermann <info@niedermann.it>