### PR TITLE
Bump Java, AGP & minSdk 🥳

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -199,7 +199,7 @@ dependencies {
     //androidTestImplementation "com.squareup.okhttp3:mockwebserver:${OKHTTP_VERSION}"
 
 
-    androidTestImplementation 'tools.fastlane:screengrab:2.0.0'
+    androidTestImplementation 'tools.fastlane:screengrab:2.1.0'
     //androidTestImplementation "org.mockito:mockito-core:MOCKITO_VERSION"
     androidTestImplementation "org.mockito:mockito-android:$MOCKITO_VERSION"
 

--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -200,6 +200,9 @@ dependencies {
 
 
     androidTestImplementation 'tools.fastlane:screengrab:2.1.0'
+    // Add falcon:2.2.0 explicitly, because screengrab:2.1.0 relies on falcon:2.1.1 which is not available on mavenCentral
+    // See https://github.com/fastlane/fastlane/issues/12651#issuecomment-849653404
+    androidTestImplementation 'com.jraska:falcon:2.2.0'
     //androidTestImplementation "org.mockito:mockito-core:MOCKITO_VERSION"
     androidTestImplementation "org.mockito:mockito-android:$MOCKITO_VERSION"
 

--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -38,6 +38,8 @@ android {
 
     compileOptions {
         coreLibraryDesugaringEnabled true
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     buildTypes {
@@ -113,7 +115,6 @@ android {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven { url "https://jitpack.io" }
     maven { url 'https://guardian.github.io/maven/repo-releases' } //needed for com.gu:option:1.3 in Android-DirectoryChooser
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogActivity.java
@@ -421,7 +421,7 @@ public class LoginDialogActivity extends AppCompatActivity {
                 });
     }
 
-	public static void ShowAlertDialog(String title, String text, Activity activity) {
+    public static void ShowAlertDialog(String title, String text, Activity activity) {
         // Linkify the message
         final SpannableString s = new SpannableString(text != null ? text : activity.getString(R.string.login_dialog_select_account_unknown_error_toast));
         Linkify.addLinks(s, Linkify.ALL);
@@ -434,8 +434,8 @@ public class LoginDialogActivity extends AppCompatActivity {
         aDialog.show();
 
         // Make the textview clickable. Must be called after show()
-		((TextView)aDialog.findViewById(android.R.id.message)).setMovementMethod(LinkMovementMethod.getInstance());
-	}
+        ((TextView) aDialog.findViewById(android.R.id.message)).setMovementMethod(LinkMovementMethod.getInstance());
+    }
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogActivity.java
@@ -21,6 +21,9 @@
 
 package de.luhmer.owncloudnewsreader;
 
+import static java.util.Objects.requireNonNull;
+import static de.luhmer.owncloudnewsreader.Constants.MIN_NEXTCLOUD_FILES_APP_VERSION_CODE;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.ProgressDialog;
@@ -38,18 +41,11 @@ import android.text.util.Linkify;
 import android.util.Log;
 import android.util.Patterns;
 import android.view.View;
-import android.widget.CheckBox;
-import android.widget.CompoundButton;
-import android.widget.CompoundButton.OnCheckedChangeListener;
-import android.widget.EditText;
-import android.widget.ImageView;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.google.android.material.textfield.TextInputLayout;
 import com.nextcloud.android.sso.AccountImporter;
 import com.nextcloud.android.sso.api.NextcloudAPI;
 import com.nextcloud.android.sso.exceptions.AccountImportCancelledException;
@@ -63,7 +59,6 @@ import com.nextcloud.android.sso.ui.UiExceptionManager;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -78,9 +73,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
-
-import static de.luhmer.owncloudnewsreader.Constants.MIN_NEXTCLOUD_FILES_APP_VERSION_CODE;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Activity which displays a login screen to the user, offering registration as
@@ -429,20 +421,19 @@ public class LoginDialogActivity extends AppCompatActivity {
                 });
     }
 
-	public static void ShowAlertDialog(String title, String text, Activity activity)
-	{
-		// Linkify the message
-		final SpannableString s = new SpannableString(text != null ? text : activity.getString(R.string.select_account_unknown_error_toast));
-		Linkify.addLinks(s, Linkify.ALL);
+	public static void ShowAlertDialog(String title, String text, Activity activity) {
+        // Linkify the message
+        final SpannableString s = new SpannableString(text != null ? text : activity.getString(R.string.login_dialog_select_account_unknown_error_toast));
+        Linkify.addLinks(s, Linkify.ALL);
 
-		AlertDialog aDialog = new AlertDialog.Builder(activity)
-				.setTitle(title)
-				.setMessage(s)
-				.setPositiveButton(activity.getString(android.R.string.ok) , null)
-				.create();
-		aDialog.show();
+        AlertDialog aDialog = new AlertDialog.Builder(activity)
+                .setTitle(title)
+                .setMessage(s)
+                .setPositiveButton(activity.getString(android.R.string.ok), null)
+                .create();
+        aDialog.show();
 
-		// Make the textview clickable. Must be called after show()
+        // Make the textview clickable. Must be called after show()
 		((TextView)aDialog.findViewById(android.R.id.message)).setMovementMethod(LinkMovementMethod.getInstance());
 	}
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -21,6 +21,11 @@
 
 package de.luhmer.owncloudnewsreader;
 
+import static androidx.annotation.VisibleForTesting.PROTECTED;
+import static de.luhmer.owncloudnewsreader.LoginDialogActivity.RESULT_LOGIN;
+import static de.luhmer.owncloudnewsreader.LoginDialogActivity.ShowAlertDialog;
+import static de.luhmer.owncloudnewsreader.SettingsActivity.PREF_SERVER_SETTINGS;
+
 import android.Manifest;
 import android.accounts.Account;
 import android.accounts.AccountManager;
@@ -32,7 +37,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
-import android.graphics.Color;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -101,7 +106,6 @@ import de.luhmer.owncloudnewsreader.databinding.ActivityNewsreaderBinding;
 import de.luhmer.owncloudnewsreader.events.podcast.FeedPanelSlideEvent;
 import de.luhmer.owncloudnewsreader.helper.DatabaseUtils;
 import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
-import de.luhmer.owncloudnewsreader.helper.ThemeUtils;
 import de.luhmer.owncloudnewsreader.model.OcsUser;
 import de.luhmer.owncloudnewsreader.reader.nextcloud.RssItemObservable;
 import de.luhmer.owncloudnewsreader.services.DownloadImagesService;
@@ -117,11 +121,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.functions.Action;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
-
-import static androidx.annotation.VisibleForTesting.PROTECTED;
-import static de.luhmer.owncloudnewsreader.LoginDialogActivity.RESULT_LOGIN;
-import static de.luhmer.owncloudnewsreader.LoginDialogActivity.ShowAlertDialog;
-import static de.luhmer.owncloudnewsreader.SettingsActivity.PREF_SERVER_SETTINGS;
 
 /**
  * An activity representing a list of NewsReader. This activity has different
@@ -434,20 +433,19 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
             } else if(exception instanceof TokenMismatchException) {
                 Toast.makeText(NewsReaderListActivity.this, "Token out of sync. Please reauthenticate", Toast.LENGTH_LONG).show();
 
-                try {
-                    SingleAccountHelper.reauthenticateCurrentAccount(this);
-                } catch (NextcloudFilesAppAccountNotFoundException | NoCurrentAccountSelectedException | NextcloudFilesAppNotSupportedException e) {
-                    UiExceptionManager.showDialogForException(this, e);
-                } catch (NextcloudFilesAppAccountPermissionNotGrantedException e) {
-                    // Unable to reauthenticate account just like that..
-                    startLoginActivity();
-                }
-                //StartLoginFragment(this);
-
-            } else {
-                UiExceptionManager.showDialogForException(this, (SSOException) exception);
-                //UiExceptionManager.showNotificationForException(this, (SSOException) exception);
-            }
+				try {
+					SingleAccountHelper.reauthenticateCurrentAccount(this);
+				} catch (NextcloudFilesAppAccountNotFoundException | NoCurrentAccountSelectedException | NextcloudFilesAppNotSupportedException e) {
+					UiExceptionManager.showDialogForException(this, e);
+				} catch (NextcloudFilesAppAccountPermissionNotGrantedException e) {
+					// Unable to reauthenticate account just like that..
+					startLoginActivity();
+				}
+				//StartLoginFragment(this);
+			} else {
+				UiExceptionManager.showDialogForException(this, (SSOException) exception);
+				//UiExceptionManager.showNotificationForException(this, (SSOException) exception);
+			}
         } else {
             Toast.makeText(NewsReaderListActivity.this, exception.getLocalizedMessage(), Toast.LENGTH_LONG).show();
         }
@@ -565,7 +563,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 	@Override
 	public void onUserInfoUpdated(OcsUser userInfo) {
-		final int placeHolder = R.drawable.ic_baseline_account_circle_24;
+		final Drawable placeHolder = getDrawable(R.drawable.ic_baseline_account_circle_24);
 		DisplayImageOptions displayImageOptions = new DisplayImageOptions.Builder()
 				.displayer(new CircleBitmapDisplayer())
 				.showImageOnLoading(placeHolder)
@@ -575,7 +573,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 				.cacheInMemory(true)
 				.build();
 
-		if(userInfo.getId() != null) {
+		if (userInfo.getId() != null) {
 			String mOc_root_path = mPrefs.getString(SettingsActivity.EDT_OWNCLOUDROOTPATH_STRING, null);
 			String avatarUrl = mOc_root_path + "/index.php/avatar/" + Uri.encode(userInfo.getId()) + "/64";
 			ImageLoader.getInstance().displayImage(avatarUrl, binding.toolbarLayout.avatar, displayImageOptions);
@@ -730,8 +728,6 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
                 clearSearchViewFocus();
             }
         });
-
-        ThemeUtils.colorSearchViewCursorColor(mSearchView, Color.WHITE);
 
         NewsReaderDetailFragment ndf = getNewsReaderDetailFragment();
         if(ndf != null) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -430,9 +430,8 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
                         getString(R.string.login_dialog_text_news_app_not_installed_on_server,
                                 "https://github.com/nextcloud/news/blob/master/docs/install.md#installing-from-the-app-store"),
                         this);
-            } else if(exception instanceof TokenMismatchException) {
-                Toast.makeText(NewsReaderListActivity.this, "Token out of sync. Please reauthenticate", Toast.LENGTH_LONG).show();
-
+            } else if (exception instanceof TokenMismatchException) {
+				Toast.makeText(NewsReaderListActivity.this, "Token out of sync. Please reauthenticate", Toast.LENGTH_LONG).show();
 				try {
 					SingleAccountHelper.reauthenticateCurrentAccount(this);
 				} catch (NextcloudFilesAppAccountNotFoundException | NoCurrentAccountSelectedException | NextcloudFilesAppNotSupportedException e) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ThemeUtils.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ThemeUtils.java
@@ -21,88 +21,28 @@
 
 package de.luhmer.owncloudnewsreader.helper;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.graphics.ColorFilter;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.util.Log;
 import android.view.Menu;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.ImageButton;
-import android.widget.SearchView;
-import android.widget.TextView;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.widget.ActionMenuView;
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.content.ContextCompat;
-
-import java.lang.reflect.Field;
-
-import de.luhmer.owncloudnewsreader.R;
 
 public class ThemeUtils {
 
-    private static final String TAG = ThemeUtils.class.getCanonicalName();
+    // private static final String TAG = ThemeUtils.class.getCanonicalName();
 
     private ThemeUtils() {}
-
-    /**
-     * Sets the color of the SearchView to {@code color} (cursor.
-     * @param searchView
-     */
-    public static void colorSearchViewCursorColor(SearchView searchView, @ColorInt int color) {
-        try {
-            Field searchTextViewRef = SearchView.class.getDeclaredField("mSearchSrcTextView");
-            searchTextViewRef.setAccessible(true);
-            Object searchAutoComplete = searchTextViewRef.get(searchView);
-
-            // FIXME Reflective access to mTextSelectHandleRes will throw an exception when targeting API 30 and above
-            @SuppressLint("SoonBlockedPrivateApi") Field mCursorDrawableRes = TextView.class.getDeclaredField("mCursorDrawableRes");
-            mCursorDrawableRes.setAccessible(true);
-            mCursorDrawableRes.set(searchAutoComplete, R.drawable.cursor);
-
-            // Set color of handle
-            // https://stackoverflow.com/a/49555923
-
-            //get the pointer resource id
-            // FIXME Reflective access to mTextSelectHandleRes will throw an exception when targeting API 30 and above
-            @SuppressLint("SoonBlockedPrivateApi") Field textSelectHandleRef = TextView.class.getDeclaredField("mTextSelectHandleRes");
-            textSelectHandleRef.setAccessible(true);
-            int drawableResId = textSelectHandleRef.getInt(searchAutoComplete);
-
-            //get the editor
-            Field editorRef = TextView.class.getDeclaredField("mEditor");
-            editorRef.setAccessible(true);
-            Object editor = editorRef.get(searchAutoComplete);
-
-            //tint drawable
-            Drawable drawable = ContextCompat.getDrawable(searchView.getContext(), drawableResId);
-            drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
-
-            //set the drawable
-            Field mSelectHandleCenter = editor.getClass().getDeclaredField("mSelectHandleCenter");
-            mSelectHandleCenter.setAccessible(true);
-            mSelectHandleCenter.set(editor, drawable);
-
-            Field mSelectHandleLeft = editor.getClass().getDeclaredField("mSelectHandleLeft");
-            mSelectHandleLeft.setAccessible(true);
-            mSelectHandleLeft.set(editor, drawable);
-
-            Field mSelectHandleRight = editor.getClass().getDeclaredField("mSelectHandleRight");
-            mSelectHandleRight.setAccessible(true);
-            mSelectHandleRight.set(editor, drawable);
-        } catch (Exception e) {
-            Log.w(TAG, "Couldn't apply color to search view cursor", e);
-        }
-    }
-
 
     /**
      * Use this method to colorize the toolbar to the desired target color

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ThemeUtils.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ThemeUtils.java
@@ -21,6 +21,7 @@
 
 package de.luhmer.owncloudnewsreader.helper;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.graphics.ColorFilter;
 import android.graphics.PorterDuff;
@@ -62,7 +63,8 @@ public class ThemeUtils {
             searchTextViewRef.setAccessible(true);
             Object searchAutoComplete = searchTextViewRef.get(searchView);
 
-            Field mCursorDrawableRes = TextView.class.getDeclaredField("mCursorDrawableRes");
+            // FIXME Reflective access to mTextSelectHandleRes will throw an exception when targeting API 30 and above
+            @SuppressLint("SoonBlockedPrivateApi") Field mCursorDrawableRes = TextView.class.getDeclaredField("mCursorDrawableRes");
             mCursorDrawableRes.setAccessible(true);
             mCursorDrawableRes.set(searchAutoComplete, R.drawable.cursor);
 
@@ -70,7 +72,8 @@ public class ThemeUtils {
             // https://stackoverflow.com/a/49555923
 
             //get the pointer resource id
-            Field textSelectHandleRef = TextView.class.getDeclaredField("mTextSelectHandleRes");
+            // FIXME Reflective access to mTextSelectHandleRes will throw an exception when targeting API 30 and above
+            @SuppressLint("SoonBlockedPrivateApi") Field textSelectHandleRef = TextView.class.getDeclaredField("mTextSelectHandleRes");
             textSelectHandleRef.setAccessible(true);
             int drawableResId = textSelectHandleRef.getInt(searchAutoComplete);
 

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -357,6 +357,7 @@
     <string name="login_dialog_text_not_compatible">This App version is not compatible with your Nextcloud News App. Please upgrade the news app and the appframework.</string>
     <string name="login_dialog_title_security_warning">Security Warning</string>
     <string name="login_dialog_text_security_warning">You\'re not using HTTPS, which is strongly encouraged. An attacker could intercept your traffic and gain access to some sensitive data (e.g. your password).</string>
+    <string name="login_dialog_select_account_unknown_error_toast">Something went wrong. Please try again.</string>
 
 
     <!-- Data & Sync -->

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:7.0.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,18 +2,17 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:7.0.0'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
         maven { url "https://jitpack.io" }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,8 @@
 # org.gradle.parallel=true
 
 ANDROID_BUILD_MIN_SDK_VERSION=21
-ANDROID_BUILD_TARGET_SDK_VERSION=29
-ANDROID_BUILD_SDK_VERSION=29
+ANDROID_BUILD_TARGET_SDK_VERSION=30
+ANDROID_BUILD_SDK_VERSION=30
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
+org.gradle.jvmargs=-Xmx4096m

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
- Upgrade to **Java 11**
  - Enables new features (See [Java 10](https://www.baeldung.com/java-10-overview) and [Java 11](https://www.baeldung.com/java-11-new-features)) like
    - `var` keywords
    - new String methods (for example `"".lines()` or `"".isBlank()`)
    - new Collection methods (for example `list.toArray(...)`)
    - extended support for type inference
- Upgrade to **AGP 7.0.0**
  - Requires Android Studio Arctic Fox AFAIK, [released yesterday](https://android-developers.googleblog.com/2021/07/android-studio-arctic-fox-202031-stable.html).
- Upgrade to **minSdk 30**
  - Required for Play Store [starting August](https://developer.android.com/distribute/best-practices/develop/target-sdk).
  - [x] @David-Development please double check everything related to file system, for example OOPML im- / export etc.

# ToDo

- [x] Linter fails because `falcon:2.1.1` could not be found
  - Add `falcon:2.2.0` explicitly, because `screengrab:2.1.0` relies on `falcon:2.1.1` which is not available on mavenCentral (see https://github.com/fastlane/fastlane/issues/12651#issuecomment-849653404)
- Using reflection to color the cursor in `ThemeUtils`
  - The app won't crash (it is in a `try / catch` block)
  - The app won't apply cursor colors for the  search view on API 30+
  - `FIXME` comments are added
  - [x] @David-Development please test whether this is actually relevant after [the redesign](https://github.com/nextcloud/news-android/pull/943)

Signed-off-by: Stefan Niedermann <info@niedermann.it>