### PR TITLE
Fix details fragment title refreshing

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -59,7 +59,6 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.util.List;
-import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -111,7 +110,7 @@ public class NewsReaderDetailFragment extends Fragment {
     private int previousFirstVisibleItem = -1;
 
     private Long idFolder;
-    private String titel;
+    private String title;
     private int onResumeCount = 0;
     private RecyclerView.OnItemTouchListener itemTouchListener;
 
@@ -179,8 +178,13 @@ public class NewsReaderDetailFragment extends Fragment {
     /**
      * @return the titel
      */
-    public String getTitel() {
-        return titel;
+    public String getTitle() {
+        return title;
+    }
+
+    protected void setTitle(String title) {
+        this.title = title;
+        requireNonNull(mActivity.getSupportActionBar()).setTitle(title);
     }
 
     protected void setData(Long idFeed, Long idFolder, String title, boolean updateListView) {
@@ -188,8 +192,7 @@ public class NewsReaderDetailFragment extends Fragment {
 
         this.idFeed = idFeed;
         this.idFolder = idFolder;
-        this.titel = title;
-        requireNonNull(mActivity.getSupportActionBar()).setTitle(title);
+        setTitle(title);
 
         if (updateListView) {
             updateCurrentRssView();

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -101,6 +101,7 @@ import de.luhmer.owncloudnewsreader.adapter.RssItemViewHolder;
 import de.luhmer.owncloudnewsreader.authentication.AccountGeneral;
 import de.luhmer.owncloudnewsreader.database.DatabaseConnectionOrm;
 import de.luhmer.owncloudnewsreader.database.model.Feed;
+import de.luhmer.owncloudnewsreader.database.model.Folder;
 import de.luhmer.owncloudnewsreader.database.model.RssItem;
 import de.luhmer.owncloudnewsreader.databinding.ActivityNewsreaderBinding;
 import de.luhmer.owncloudnewsreader.events.podcast.FeedPanelSlideEvent;
@@ -487,6 +488,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 		newsReaderListFragment.reloadAdapter();
 		UpdateItemList();
 		updatePodcastView();
+		updateDetailFragmentTitle();
 
 		if(mApi.getNewsAPI() != null) {
             getSlidingListFragment().startAsyncTaskGetUserInfo();
@@ -681,6 +683,42 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
         fragment.setData(feedId, folderId, title, updateListView);
         return fragment;
     }
+
+	private void updateDetailFragmentTitle() {
+		NewsReaderDetailFragment fragment = getNewsReaderDetailFragment();
+		Long id = fragment.getIdFeed() == null ? fragment.getIdFolder() : fragment.getIdFeed();
+		if (id == null) {
+			return;
+		}
+
+		DatabaseConnectionOrm dbConn = new DatabaseConnectionOrm(getApplicationContext());
+
+		String title = null;
+		boolean isFolder = fragment.getIdFolder() == null;
+
+		if (isFolder) {
+			int idFolder = id.intValue();
+			if (idFolder >= 0) {
+				Folder folder = dbConn.getFolderById(id);
+				if (folder == null) {
+					return;
+				}
+				title = folder.getLabel();
+			} else if (idFolder == -10) {
+				title = getString(R.string.allUnreadFeeds);
+			} else if (idFolder == -11) {
+				title = getString(R.string.starredFeeds);
+			}
+		} else {
+			Feed feed = dbConn.getFeedById(id);
+			if (feed == null) {
+				return;
+			}
+			title = feed.getFeedTitle();
+		}
+
+		fragment.setTitle(title);
+	}
 
 
     public void UpdateItemList() {
@@ -1090,7 +1128,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 			Intent intentNewsDetailAct = new Intent(this, NewsDetailActivity.class);
 
 			intentNewsDetailAct.putExtra(NewsReaderListActivity.ITEM_ID, position);
-			intentNewsDetailAct.putExtra(NewsReaderListActivity.TITLE, getNewsReaderDetailFragment().getTitel());
+			intentNewsDetailAct.putExtra(NewsReaderListActivity.TITLE, getNewsReaderDetailFragment().getTitle());
 			startActivityForResult(intentNewsDetailAct, Activity.RESULT_CANCELED);
 		}
 	}


### PR DESCRIPTION
When we update the feed/folder name in the app itself, or when the changes come from the server, the title of the current fragment isn't updated. I've made a fix that updates the title after every sync.