### PR TITLE
Delete cached entities to keep entity relationships up to date

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/authentication/OwnCloudSyncAdapter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/authentication/OwnCloudSyncAdapter.java
@@ -164,6 +164,11 @@ public class OwnCloudSyncAdapter extends AbstractThreadedSyncAdapter {
         try {
             NextcloudSyncResult syncResult = combined.blockingFirst();
 
+            // Delete cached entities to keep entity relationships up to date for observers and readers,
+            // for example, relationship of RSS items with feeds that have changed (name changed, etc).
+            // The presence of old data in the cache can affect the obtaining of up-to-date information.
+            dbConn.clearSessionCache();
+
             InsertIntoDatabase.InsertFoldersIntoDatabase(syncResult.folders, dbConn);
             InsertIntoDatabase.InsertFeedsIntoDatabase(syncResult.feeds, dbConn);
             Log.v(TAG, "State sync successful: " + syncResult.stateSyncSuccessful);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
@@ -856,4 +856,8 @@ public class DatabaseConnectionOrm {
         }
         return sb.toString();
     }
+
+    public void clearSessionCache() {
+        daoSession.clear();
+    }
 }


### PR DESCRIPTION
Related to #1075. 

Because greenDAO has internal caching for the current session, there have been out-of-date data issues when fetching RSS items from the DB. This is because `RssItem` and `Feed` entities already have their own internal caching for "many-to-one" and "one-to-many" relationships. There were three ways out of the situation:
1. Completely remove relationship caching in entities
2. Use `RssItemDao#deepQuery()`, but this limits greenDAO's query flexibility
3. Clear session cache after synchronization

I think option (3) is the best option in this case, because it affects all entities at once, not just `RssItem`, and we don't violate or interfere with the original entity caching logic, which would have to be removed. Option (2) requires the use of a similar method in `Feed` and other entities that use relationship caching. Currently, problems are observed only with `RssItem`, but this doesn't mean that in the future (or already now) there are problems with other entities, which means that we eliminate a whole layer of possible bugs with option (3) or (1).

This PR implements strategy (3), but  strategy (1) is also possible if strategy (3) causes any problems. I quickly checked the synchronization and didn't notice any breaking changes.

Close #1075