### PR TITLE
Accept single URLs (hostname only) as valid

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogActivity.java
@@ -307,9 +307,6 @@ public class LoginDialogActivity extends AppCompatActivity {
         } else {
             try {
                 URL url = new URL(mOc_root_path);
-                if(!Patterns.WEB_URL.matcher(mOc_root_path).matches()) {
-                    throw new MalformedURLException();
-                }
                 if (!url.getProtocol().equals("https")) {
                     ShowAlertDialog(getString(R.string.login_dialog_title_security_warning),
                             getString(R.string.login_dialog_text_security_warning), this);


### PR DESCRIPTION
I cannot login using the manual method (it works using Nextcloud File's login) because I'm using a single URL (https://foo) which fails to pass `Patterns.WEB_URL` validation. This kind of URLs can be used in combination with Tailscale's magic DNS feature.

You already prepend `https://` when the strings doesn't start with `http://` and once you have that, I suppose java's URL validation is enough.