### PR TITLE
External player support

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
@@ -575,7 +575,7 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 	 */
 	private void startTTS(int currentPosition) {
 		RssItem rssItem = rssItems.get(currentPosition);
-		String text = rssItem.getTitle() + "\n\n " + Html.fromHtml(rssItem.getBody()).toString();
+		String text = rssItem.getTitle() + ". " + Html.fromHtml(rssItem.getBody()).toString();
 		// Log.d(TAG, text);
 		TTSItem ttsItem = new TTSItem(rssItem.getId(), rssItem.getAuthor(), rssItem.getTitle(), text, rssItem.getFeed().getFaviconUrl());
 		openMediaItem(ttsItem);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
@@ -259,28 +259,27 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
 
     @VisibleForTesting
     public void openMediaItem(final MediaItem mediaItem) {
-        if (mPrefs.getBoolean(SettingsActivity.CB_EXTERNAL_PLAYER, false)) {
-            Uri uri = mediaItem.link.startsWith("/")
+        if (mPrefs.getBoolean(SettingsActivity.CB_EXTERNAL_PLAYER, false) && mediaItem instanceof PodcastItem) {
+            // PodcastItems can be audio or video
+            Uri uri = ((PodcastItem) mediaItem).offlineCached // in case it's locally cached (offline)
                     ? FileProvider.getUriForFile(this, BuildConfig.APPLICATION_ID + ".provider", new File(mediaItem.link))
                     : Uri.parse(mediaItem.link);
+
             Intent intent = new Intent(Intent.ACTION_VIEW);
-            if (mediaItem instanceof PodcastItem) intent.setDataAndType(uri, ((PodcastItem) mediaItem).mimeType);
-            else intent.setDataAndType(uri, "audio/*");
+            intent.setDataAndType(uri, ((PodcastItem) mediaItem).mimeType);
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             startActivity(intent);
         } else {
+            // in case the user wants to use the internal player or we have a TTS item (text to speech)
             Intent intent = new Intent(this, PodcastPlaybackService.class);
             intent.putExtra(PodcastPlaybackService.MEDIA_ITEM, mediaItem);
             startService(intent);
 
-            /*
-            if(!mMediaBrowser.isConnected()) {
-                mMediaBrowser.connect();
-            }
-            */
 
-
-            //bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
+            // if(!mMediaBrowser.isConnected()) {
+            //    mMediaBrowser.connect();
+            // }
+            // bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
         }
     }
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -82,6 +82,8 @@ public class SettingsActivity extends AppCompatActivity {
     public static final String SP_APP_THEME = "sp_app_theme";
     public static final String CB_OLED_MODE = "cb_oled_mode";
 
+    public static final String CB_EXTERNAL_PLAYER = "cb_external_player";
+
     public static final String SP_FEED_LIST_LAYOUT = "sp_feed_list_layout"; // used for shared prefs
     public static final String RI_FEED_LIST_LAYOUT = "ai_feed_list_layout"; // used for result intents
     public static final String SP_FONT_SIZE = "sp_font_size";

--- a/News-Android-App/src/main/res/values-de/strings.xml
+++ b/News-Android-App/src/main/res/values-de/strings.xml
@@ -208,6 +208,9 @@
     <string name="pref_oled_mode">Schwarzer Hintergrund</string>
     <string name="pref_oled_mode_summary">Für dunkles Design auf OLED-Bildschirmen</string>
 
+    <string name="pref_external_player">Externes Wiedergabeprogramm</string>
+    <string name="pref_external_player_summary">Spiele Podcasts in der standard-Applikation</string>
+
     <string name="pref_display_browser_cct">Integrierte angepasste Chrome-Tabs</string>
     <string name="pref_display_browser_built_in">Integrierter Browser</string>
     <string name="pref_display_browser_external">Externer Browser</string>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -273,6 +273,9 @@
     <string name="pref_oled_mode">Black background</string>
     <string name="pref_oled_mode_summary">For dark theme on OLED screens</string>
 
+    <string name="pref_external_player">External Player</string>
+    <string name="pref_external_player_summary">Play podcasts in your default media app</string>
+
     <string-array name="pref_title_lines_count" translatable="false">
         <item>1</item>
         <item>2</item>

--- a/News-Android-App/src/main/res/xml/pref_display.xml
+++ b/News-Android-App/src/main/res/xml/pref_display.xml
@@ -53,6 +53,13 @@
             android:title="@string/pref_display_browser"
             app:iconSpaceReserved="false"/>
 
+        <SwitchPreference
+            android:key="cb_external_player"
+            android:title="@string/pref_external_player"
+            android:summary="@string/pref_external_player_summary"
+            android:defaultValue="false"
+            app:iconSpaceReserved="false"/>
+
         <MultiSelectListPreference
             android:entries="@array/pref_display_news_detail_actionbar_icons"
             android:entryValues="@array/pref_display_news_detail_actionbar_icons_values"


### PR DESCRIPTION
This PR adds support for optionally playing podcasts in an external app.
Closes #1094 
I'm not really happy with the special casing needed here to handle the different MediaItem types and downloaded podcasts, but it does seem to work.