### PR TITLE
Fix lint errors

### DIFF
--- a/News-Android-App/src/main/AndroidManifest.xml
+++ b/News-Android-App/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="internalOnly">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PiPVideoPlaybackActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PiPVideoPlaybackActivity.java
@@ -67,12 +67,15 @@ public class PiPVideoPlaybackActivity extends AppCompatActivity {
 
     @Override
     public void onPictureInPictureModeChanged (boolean isInPictureInPictureMode, Configuration newConfig) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig);
+        }
         Log.d(TAG, "onPictureInPictureModeChanged() called with: isInPictureInPictureMode = [" + isInPictureInPictureMode + "], newConfig = [" + newConfig + "]");
 
         RelativeLayout surfaceViewWrapper = findViewById(R.id.layout_activity_pip);
         SurfaceView surfaceView = (SurfaceView) surfaceViewWrapper.getChildAt(0);
 
-        if(surfaceView != null) {
+        if (surfaceView != null) {
             if (isInPictureInPictureMode) {
                 surfaceView.setLayoutParams(new RelativeLayout.LayoutParams(
                         RelativeLayout.LayoutParams.MATCH_PARENT,


### PR DESCRIPTION
Especially
`/home/runner/work/news-android/news-android/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/DownloadImagesService.java:145: Error: When targeting Android 13 or higher, posting a permission requires holding the POST_NOTIFICATIONS permission [NotificationPermission]`
sounds like it should be fixed before publishing.

Haven't had a chance to test PiP mode, so please check if it still works as expected.