### PR TITLE
Avoid running ci two times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ jobs:
   validation:
     name: Validate Gradle Wrapper
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
@@ -12,7 +13,7 @@ jobs:
   lint:
     name: Run Lint Checks
     runs-on: ubuntu-latest
-
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v3
       - name: set up JDK 11
@@ -26,6 +27,7 @@ jobs:
   test:
     name: Run Unit Tests
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v3
       - name: set up JDK 11
@@ -39,6 +41,7 @@ jobs:
   codeql:
     name: CodeQL security scan
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -54,6 +57,7 @@ jobs:
   apk:
     name: Generate APK
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v3
       - name: set up JDK 11


### PR DESCRIPTION
This shoud avoid running CI for PRs which originate from this repo where CI is already run via push.

Should fix failing checks for dependabot PRs this way.

edit: Looks working 👍 