### PR TITLE
fix export issues on Android 11 and above

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
@@ -1,18 +1,21 @@
 package de.luhmer.owncloudnewsreader;
 
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static java.util.Objects.requireNonNull;
 
 import android.Manifest;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
+import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Xml;
@@ -42,8 +45,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -80,6 +85,29 @@ public class NewFeedActivity extends AppCompatActivity {
 
     private List<Folder> folders;
     protected @Inject ApiProvider mApi;
+
+    protected boolean useMediaStore = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R;
+
+    @NonNull
+    public static String convertStreamToString(InputStream is) throws Exception {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            sb.append(line).append("\n");
+        }
+        reader.close();
+        return sb.toString();
+    }
+
+    public static String getStringFromFile(String filePath) throws Exception {
+        File fl = new File(filePath);
+        FileInputStream fin = new FileInputStream(fl);
+        String ret = convertStreamToString(fin);
+        //Make sure you close all streams.
+        fin.close();
+        return ret;
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -124,11 +152,11 @@ public class NewFeedActivity extends AppCompatActivity {
             String url = "";
             if (action.equals(Intent.ACTION_VIEW)) {
                 url = intent.getDataString();
-            } else if(action.equals(Intent.ACTION_SEND)) {
+            } else if (action.equals(Intent.ACTION_SEND)) {
                 url = intent.getStringExtra(Intent.EXTRA_TEXT);
             }
 
-            if(url != null && url.endsWith(".opml")) {
+            if (url != null && url.endsWith(".opml")) {
                 AsyncTaskHelper.StartAsyncTask(new ImportOpmlSubscriptionsTask(url, NewFeedActivity.this));
             }
 
@@ -136,14 +164,19 @@ public class NewFeedActivity extends AppCompatActivity {
             //ContentResolver resolver = getContentResolver();
 
             //Uri uri = intent.getData();
-            Log.v("tag" , "Content intent detected: " + action + " : " + url);
+            Log.v("tag", "Content intent detected: " + action + " : " + url);
             binding.etFeedUrl.setText(url);
         }
     }
 
+    private void openFilePicker() {
+        startActivityForResult(new Intent(Intent.ACTION_GET_CONTENT)
+                .addCategory(Intent.CATEGORY_OPENABLE).setType("*/*"), REQUEST_CODE_OPML_IMPORT);
+    }
+
     public void btnAddFeedClick() {
-        //Hide keyboard
-        InputMethodManager imm = (InputMethodManager)getSystemService(
+        // Hide keyboard
+        InputMethodManager imm = (InputMethodManager) getSystemService(
                 Context.INPUT_METHOD_SERVICE);
         imm.hideSoftInputFromWindow(binding.etFeedUrl.getWindowToken(), 0);
 
@@ -153,9 +186,9 @@ public class NewFeedActivity extends AppCompatActivity {
     public void importOpml() {
         String permission = Manifest.permission.READ_EXTERNAL_STORAGE;
 
-        if (ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
+        if (ContextCompat.checkSelfPermission(this, permission) != PERMISSION_GRANTED) {
             if (ActivityCompat.shouldShowRequestPermissionRationale(this, permission)) {
-                Toast.makeText(this, "Allow external storage reading", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, "Please enable \"Read\" permission for Files and Media for the Nextcloud News App", Toast.LENGTH_SHORT).show();
             } else {
                 ActivityCompat.requestPermissions(this, new String[]{permission}, PERMISSIONS_REQUEST_READ_CODE);
             }
@@ -163,52 +196,6 @@ public class NewFeedActivity extends AppCompatActivity {
             openFilePicker();
         }
 
-    }
-
-    private void openFilePicker() {
-        startActivityForResult(new Intent(Intent.ACTION_GET_CONTENT)
-                .addCategory(Intent.CATEGORY_OPENABLE).setType("*/*"), REQUEST_CODE_OPML_IMPORT);
-    }
-
-    public void exportOpml() {
-        String permission = Manifest.permission.WRITE_EXTERNAL_STORAGE;
-
-        if (ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
-            if (ActivityCompat.shouldShowRequestPermissionRationale(this, permission)) {
-                Toast.makeText(this, "Allow external storage writing", Toast.LENGTH_SHORT).show();
-            } else {
-                ActivityCompat.requestPermissions(this, new String[]{permission}, PERMISSIONS_REQUEST_WRITE_CODE);
-            }
-        } else {
-            exportOpmlFile();
-        }
-    }
-
-    private void exportOpmlFile() {
-        String xml = OpmlXmlParser.GenerateOPML(this);
-
-        //String path = NewsFileUtils.getCacheDirPath(this) + "/subscriptions.opml";
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
-        String filename = "subscriptions-" + format.format(new Date()) + ".opml";
-        File path = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), filename);
-
-        try {
-            FileOutputStream fos = new FileOutputStream(path);
-            OutputStreamWriter outputStreamWriter = new OutputStreamWriter(fos);
-            outputStreamWriter.write(xml);
-            outputStreamWriter.close();
-            fos.close();
-
-            new AlertDialog.Builder(this)
-                    .setMessage(getString(R.string.successfully_exported) + " " + path)
-                    .setTitle(getString(R.string.opml_export))
-                    .setNeutralButton(getString(android.R.string.ok), null)
-                    .create()
-                    .show();
-        }
-        catch (IOException e) {
-            Log.e("Exception", "File write failed: " + e.toString());
-        }
     }
 
     @Override
@@ -243,6 +230,232 @@ public class NewFeedActivity extends AppCompatActivity {
                     Toast.makeText(this, "Unknown URI scheme: " + importUri.getScheme(), Toast.LENGTH_LONG).show();
             }
         }
+    }
+
+    public void exportOpml() {
+        String permission = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+
+        if (useMediaStore) {
+            exportOpmlFile();
+        } else {
+            if (ContextCompat.checkSelfPermission(this, permission) != PERMISSION_GRANTED) {
+                if (ActivityCompat.shouldShowRequestPermissionRationale(this, permission)) {
+                    Toast.makeText(this, "Please enable \"Write\" permission for Files and Media for the Nextcloud News App", Toast.LENGTH_SHORT).show();
+                } else {
+                    ActivityCompat.requestPermissions(this, new String[]{permission}, PERMISSIONS_REQUEST_WRITE_CODE);
+                }
+            } else {
+                exportOpmlFile();
+            }
+        }
+    }
+
+    private void exportOpmlFile() {
+        String xml = OpmlXmlParser.GenerateOPML(this);
+
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        String filename = "subscriptions-" + format.format(new Date()) + ".opml";
+
+        try {
+            String path = "";
+            if (useMediaStore) {
+                // Android 11 and above
+                ContentResolver contentResolver = getContentResolver();
+                ContentValues contentValues = new ContentValues();
+                contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, filename);
+                contentValues.put(MediaStore.MediaColumns.MIME_TYPE, "application/xml");
+                contentValues.put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS);
+                Uri uri = contentResolver.insert(MediaStore.Files.getContentUri("external"), contentValues);
+                path = "/storage/Downloads/" + filename; // in case we use MediaStore we can't get the cleartext path
+                OutputStream out = contentResolver.openOutputStream(uri);
+                out.write(xml.getBytes(StandardCharsets.UTF_8));
+                out.close();
+            } else {
+                // Android 10 and below
+                File fPath = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), filename);
+                path = fPath.getPath();
+                FileOutputStream fos = new FileOutputStream(fPath);
+                OutputStreamWriter outputStreamWriter = new OutputStreamWriter(fos);
+                outputStreamWriter.write(xml);
+                outputStreamWriter.close();
+                fos.close();
+            }
+
+            new AlertDialog.Builder(this)
+                    .setMessage(getString(R.string.successfully_exported) + " " + path)
+                    .setTitle(getString(R.string.opml_export))
+                    .setNeutralButton(getString(android.R.string.ok), null)
+                    .create()
+                    .show();
+        } catch (IOException e) {
+            Log.e("Exception", "File write failed: " + e);
+            new AlertDialog.Builder(this)
+                    .setMessage("Failed to export OPML - please report this issue - " + e.getMessage())
+                    .setTitle(getString(R.string.opml_export))
+                    .setNeutralButton(getString(android.R.string.ok), null)
+                    .create()
+                    .show();
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(
+            int requestCode,
+            @NonNull String[] permissions,
+            @NonNull int[] grantResults
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        // check if user granted the requested permission
+        if (grantResults.length > 0 && grantResults[0] == PERMISSION_GRANTED) {
+            if (requestCode == PERMISSIONS_REQUEST_READ_CODE) {
+                // user tried to import OPML -> retry after the permission has been granted
+                importOpml();
+            } else if (requestCode == PERMISSIONS_REQUEST_WRITE_CODE) {
+                // user tried to export OPML -> retry after the permission has been granted
+                exportOpml();
+            }
+        }
+    }
+
+    public static String truncate(String str, int len) {
+        if (str.length() > len) {
+            return str.substring(0, len) + "...";
+        } else {
+            return str;
+        }
+    }
+
+    private boolean isUrlValid(String url) {
+        try {
+            new URL(url);
+            return true;
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return false;
+    }
+
+    /**
+     * Attempts to sign in or register the account specified by the login form.
+     * If there are form errors (invalid email, missing fields, etc.), the
+     * errors are presented and no actual login attempt is made.
+     */
+    public void attemptAddNewFeed() {
+        Folder folder = folders.get(binding.spFolder.getSelectedItemPosition());
+
+        // Reset errors.
+        binding.etFeedUrl.setError(null);
+
+        // Store values at the time of the login attempt.
+        String urlToFeed = binding.etFeedUrl.getText().toString();
+
+        boolean cancel = false;
+        View focusView = null;
+
+
+        // Check for a valid email address.
+        if (TextUtils.isEmpty(urlToFeed)) {
+            binding.etFeedUrl.setError(getString(R.string.error_field_required));
+            focusView = binding.etFeedUrl;
+            cancel = true;
+        } else if (!isUrlValid(urlToFeed)) {
+            binding.etFeedUrl.setError(getString(R.string.error_invalid_url));
+            focusView = binding.etFeedUrl;
+            cancel = true;
+        }
+
+        if (cancel) {
+            // There was an error; don't attempt login and focus the first
+            // form field with an error.
+            focusView.requestFocus();
+        } else {
+            // Show a progress spinner, and kick off a background task to
+            // perform the user login attempt.
+            showProgress(true);
+
+            mApi.getNewsAPI().createFeed(urlToFeed, folder.getId()).enqueue(new Callback<List<Feed>>() {
+                @Override
+                public void onResponse(@NonNull Call<List<Feed>> call, @NonNull final Response<List<Feed>> response) {
+                    runOnUiThread(() -> {
+                        showProgress(false);
+
+                        if (response.isSuccessful()) {
+                            Intent returnIntent = new Intent();
+                            returnIntent.putExtra(ADD_NEW_SUCCESS, true);
+                            setResult(RESULT_OK, returnIntent);
+
+                            finish();
+                        } else {
+                            try {
+                                String errorMessage = response.errorBody().string();
+                                try {
+                                    //Log.e(TAG, errorMessage);
+                                    JSONObject jObjError = new JSONObject(errorMessage);
+                                    errorMessage = jObjError.getString("message");
+                                    errorMessage = truncate(errorMessage, 150);
+                                } catch (JSONException e) {
+                                    Log.e(TAG, "Extracting error message failed: " + errorMessage, e);
+                                }
+                                binding.etFeedUrl.setError(errorMessage);
+                                Log.e(TAG, errorMessage);
+                            } catch (IOException e) {
+                                Log.e(TAG, "IOException", e);
+                                binding.etFeedUrl.setError(getString(R.string.login_dialog_text_something_went_wrong));
+                            }
+                            binding.etFeedUrl.requestFocus();
+                        }
+                    });
+                }
+
+                @Override
+                public void onFailure(@NonNull Call<List<Feed>> call, @NonNull final Throwable t) {
+                    runOnUiThread(() -> {
+                        showProgress(false);
+
+                        binding.etFeedUrl.setError(getString(R.string.login_dialog_text_something_went_wrong) + " - " + OkHttpSSLClient.HandleExceptions((Exception) t).getMessage());
+                        binding.etFeedUrl.requestFocus();
+                    });
+                }
+            });
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // Respond to the action bar's Up/Home button
+        if (item.getItemId() == android.R.id.home) {//NavUtils.navigateUpFromSameTask(this);
+            finish();
+            return true;
+        } else {
+            Log.v(TAG, "Unknown option selected..");
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    /**
+     * Shows the progress UI and hides the login form.
+     */
+    public void showProgress(final boolean show) {
+        int shortAnimTime = getResources().getInteger(android.R.integer.config_shortAnimTime);
+
+        binding.newFeedForm.setVisibility(show ? View.GONE : View.VISIBLE);
+        binding.newFeedForm.animate().setDuration(shortAnimTime).alpha(
+                show ? 0 : 1).setListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                binding.newFeedForm.setVisibility(show ? View.GONE : View.VISIBLE);
+            }
+        });
+
+        binding.newFeedProgress.setVisibility(show ? View.VISIBLE : View.GONE);
+        binding.newFeedProgress.animate().setDuration(shortAnimTime).alpha(
+                show ? 1 : 0).setListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                binding.newFeedProgress.setVisibility(show ? View.VISIBLE : View.GONE);
+            }
+        });
     }
 
     public class ImportOpmlSubscriptionsTask extends AsyncTask<Void, List<String>, Boolean> {
@@ -309,7 +522,7 @@ public class NewFeedActivity extends AppCompatActivity {
                 for (String feedUrl : extractedUrls.keySet()) {
                     long folderId = 0; //id of the parent folder, 0 for root
                     String folderName = extractedUrls.get(feedUrl);
-                    if(folderName != null) { //Get Folder ID (create folder if not exists)
+                    if (folderName != null) { //Get Folder ID (create folder if not exists)
                         if (!existingFolders.containsKey(folderName)) {
                             // If folder does not exist, create a new one on the server
                             final Map<String, Object> folderMap = new HashMap<>(1);
@@ -367,7 +580,7 @@ public class NewFeedActivity extends AppCompatActivity {
         protected void onPostExecute(Boolean result) {
             pd.setVisibilityOkButton(true);
 
-            if(!result) {
+            if (!result) {
                 Toast.makeText(mContext, "Failed to parse OPML file", Toast.LENGTH_SHORT).show();
             } else {
                 Toast.makeText(mContext, "Import done!", Toast.LENGTH_LONG).show();
@@ -375,170 +588,6 @@ public class NewFeedActivity extends AppCompatActivity {
 
             super.onPostExecute(result);
         }
-    }
-
-
-    /**
-     * Attempts to sign in or register the account specified by the login form.
-     * If there are form errors (invalid email, missing fields, etc.), the
-     * errors are presented and no actual login attempt is made.
-     */
-    public void attemptAddNewFeed() {
-        Folder folder = folders.get(binding.spFolder.getSelectedItemPosition());
-
-        // Reset errors.
-        binding.etFeedUrl.setError(null);
-
-        // Store values at the time of the login attempt.
-        String urlToFeed = binding.etFeedUrl.getText().toString();
-
-        boolean cancel = false;
-        View focusView = null;
-
-
-        // Check for a valid email address.
-        if (TextUtils.isEmpty(urlToFeed)) {
-            binding.etFeedUrl.setError(getString(R.string.error_field_required));
-            focusView = binding.etFeedUrl;
-            cancel = true;
-        } else if (!isUrlValid(urlToFeed)) {
-            binding.etFeedUrl.setError(getString(R.string.error_invalid_url));
-            focusView = binding.etFeedUrl;
-            cancel = true;
-        }
-
-        if (cancel) {
-            // There was an error; don't attempt login and focus the first
-            // form field with an error.
-            focusView.requestFocus();
-        } else {
-            // Show a progress spinner, and kick off a background task to
-            // perform the user login attempt.
-            showProgress(true);
-
-            mApi.getNewsAPI().createFeed(urlToFeed, folder.getId()).enqueue(new Callback<List<Feed>>() {
-                @Override
-                public void onResponse(@NonNull Call<List<Feed>> call, @NonNull final Response<List<Feed>> response) {
-                    runOnUiThread(() -> {
-                        showProgress(false);
-
-                        if (response.isSuccessful()) {
-                            Intent returnIntent = new Intent();
-                            returnIntent.putExtra(ADD_NEW_SUCCESS, true);
-                            setResult(RESULT_OK, returnIntent);
-
-                            finish();
-                        } else {
-                            try {
-                                String errorMessage = response.errorBody().string();
-                                try {
-                                    //Log.e(TAG, errorMessage);
-                                    JSONObject jObjError= new JSONObject(errorMessage);
-                                    errorMessage = jObjError.getString("message");
-                                    errorMessage = truncate(errorMessage, 150);
-                                } catch (JSONException e) {
-                                    Log.e(TAG, "Extracting error message failed: " + errorMessage, e);
-                                }
-                                binding.etFeedUrl.setError(errorMessage);
-                                Log.e(TAG, errorMessage);
-                            } catch (IOException e) {
-                                Log.e(TAG, "IOException", e);
-                                binding.etFeedUrl.setError(getString(R.string.login_dialog_text_something_went_wrong));
-                            }
-                            binding.etFeedUrl.requestFocus();
-                        }
-                    });
-                }
-
-                @Override
-                public void onFailure(@NonNull Call<List<Feed>> call, @NonNull final Throwable t) {
-                    runOnUiThread(() -> {
-                        showProgress(false);
-
-                        binding.etFeedUrl.setError(getString(R.string.login_dialog_text_something_went_wrong) + " - " + OkHttpSSLClient.HandleExceptions((Exception) t).getMessage());
-                        binding.etFeedUrl.requestFocus();
-                    });
-                }
-            });
-        }
-    }
-
-    public static String truncate(String str, int len) {
-        if (str.length() > len) {
-            return str.substring(0, len) + "...";
-        } else {
-            return str;
-        }
-    }
-
-    private boolean isUrlValid(String url) {
-        try {
-            new URL(url);
-            return true;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
-        return false;
-    }
-
-    /**
-     * Shows the progress UI and hides the login form.
-     */
-    public void showProgress(final boolean show) {
-            int shortAnimTime = getResources().getInteger(android.R.integer.config_shortAnimTime);
-
-            binding.newFeedForm.setVisibility(show ? View.GONE : View.VISIBLE);
-            binding.newFeedForm.animate().setDuration(shortAnimTime).alpha(
-                    show ? 0 : 1).setListener(new AnimatorListenerAdapter() {
-                @Override
-                public void onAnimationEnd(Animator animation) {
-                    binding.newFeedForm.setVisibility(show ? View.GONE : View.VISIBLE);
-                }
-            });
-
-            binding.newFeedProgress.setVisibility(show ? View.VISIBLE : View.GONE);
-            binding.newFeedProgress.animate().setDuration(shortAnimTime).alpha(
-                    show ? 1 : 0).setListener(new AnimatorListenerAdapter() {
-                @Override
-                public void onAnimationEnd(Animator animation) {
-                    binding.newFeedProgress.setVisibility(show ? View.VISIBLE : View.GONE);
-                }
-            });
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // Respond to the action bar's Up/Home button
-        if (item.getItemId() == android.R.id.home) {//NavUtils.navigateUpFromSameTask(this);
-            finish();
-            return true;
-        } else {
-            Log.v(TAG, "Unknown option selected..");
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
-
-
-
-    @NonNull public static String convertStreamToString(InputStream is) throws Exception {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(is));
-        StringBuilder sb = new StringBuilder();
-        String line;
-        while ((line = reader.readLine()) != null) {
-            sb.append(line).append("\n");
-        }
-        reader.close();
-        return sb.toString();
-    }
-
-    public static String getStringFromFile (String filePath) throws Exception {
-        File fl = new File(filePath);
-        FileInputStream fin = new FileInputStream(fl);
-        String ret = convertStreamToString(fin);
-        //Make sure you close all streams.
-        fin.close();
-        return ret;
     }
 }
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
@@ -86,7 +86,7 @@ public class NewFeedActivity extends AppCompatActivity {
     private List<Folder> folders;
     protected @Inject ApiProvider mApi;
 
-    protected boolean useMediaStore = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R;
+    protected boolean useMediaStore = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q;
 
     @NonNull
     public static String convertStreamToString(InputStream is) throws Exception {
@@ -259,7 +259,6 @@ public class NewFeedActivity extends AppCompatActivity {
         try {
             String path = "";
             if (useMediaStore) {
-                // Android 11 and above
                 ContentResolver contentResolver = getContentResolver();
                 ContentValues contentValues = new ContentValues();
                 contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, filename);
@@ -271,7 +270,6 @@ public class NewFeedActivity extends AppCompatActivity {
                 out.write(xml.getBytes(StandardCharsets.UTF_8));
                 out.close();
             } else {
-                // Android 10 and below
                 File fPath = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), filename);
                 path = fPath.getPath();
                 FileOutputStream fos = new FileOutputStream(fPath);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
@@ -101,6 +101,11 @@ public class NewFeedActivity extends AppCompatActivity {
     }
 
     public static String getStringFromFile(String filePath) throws Exception {
+        if (filePath.contains("..")) {
+            // Prevent java/path-injection
+            // https://github.com/nextcloud/news-android/security/code-scanning/5
+            throw new IllegalStateException("Input File path may not contain ..");
+        }
         File fl = new File(filePath);
         FileInputStream fin = new FileInputStream(fl);
         String ret = convertStreamToString(fin);

--- a/docker-nextcloud-test-instances/README.md
+++ b/docker-nextcloud-test-instances/README.md
@@ -7,7 +7,7 @@ Start image with:
   'trusted_domains' =>
     array (
       0 => 'localhost',
-      1 => '192.168.1.100',
+      1 => '*',
     ),
   ```
 4. Open Nextcloud in Browser (e.g. http://192.168.1.100)

--- a/docker-nextcloud-test-instances/docker-compose.yaml
+++ b/docker-nextcloud-test-instances/docker-compose.yaml
@@ -2,14 +2,15 @@ version: '3'
 
 services:
   app:
-    image: nextcloud:24.0.3-apache
+    # https://hub.docker.com/_/nextcloud/tags
+    image: nextcloud:26.0.1-apache
     volumes:
       - ./nextcloud-data/:/var/www/html
     #restart: no
     environment:
-     - SQLITE_DATABASE=testdatabase.sqlite
-     - NEXTCLOUD_ADMIN_USER=admin
-     - NEXTCLOUD_ADMIN_PASSWORD=admin123
+      - SQLITE_DATABASE=testdatabase.sqlite
+      - NEXTCLOUD_ADMIN_USER=admin
+      - NEXTCLOUD_ADMIN_PASSWORD=admin123
     ports:
       - "80:80"
     # - "443:443"


### PR DESCRIPTION
- Implements OnRequestPermissionsResultCallback and automatically triggers import/export again after required permission has been granted
- Uses new MediaStore API for Android 11 and above (which doesn't require permission dialog anymore)
- Autoformatted code..

Closes https://github.com/nextcloud/news-android/issues/1188