### PR TITLE
add line-height for h1 tags

### DIFF
--- a/News-Android-App/src/main/assets/web.css
+++ b/News-Android-App/src/main/assets/web.css
@@ -224,6 +224,10 @@ ul li:before {
     line-height:    1.5em !important;
 }
 
+h1 {
+    line-height: 1em !important;
+}
+
 #imgFavicon {
     margin-right: 4px;
     vertical-align:middle;


### PR DESCRIPTION
This patch adds line-height to h1 tags to remove  text overlap.

Before:
![Before](https://github.com/nextcloud/news-android/assets/18418792/b5daeaba-ec60-487f-8649-2dd7bd0bbe53)

After:
![After](https://github.com/nextcloud/news-android/assets/18418792/c31fd02f-54ac-47eb-99c5-455f07b0d917)
