### PR TITLE
Add shortcut to "Show only unread articles" in the toolbar

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'kotlin-kapt'
     id 'com.google.devtools.ksp'
     id 'io.gitlab.arturbosch.detekt' version "1.23.0"
-    id "com.diffplug.spotless" version "6.19.0"
+    id "com.diffplug.spotless" version "6.21.0"
 }
 
 android {

--- a/News-Android-App/src/main/res/menu/news_reader.xml
+++ b/News-Android-App/src/main/res/menu/news_reader.xml
@@ -41,6 +41,13 @@
         android:title="@string/menu_markAllAsRead"/>
 
     <item
+        android:id="@+id/menu_toggleShowOnlyUnread"
+        android:orderInCategory="98"
+        android:title="@string/pref_title_ShowOnlyUnread"
+        android:checkable="true"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_add_new_feed"
         android:orderInCategory="101"
         app:showAsAction="never"


### PR DESCRIPTION
This PR adds a shortcut to "Show only unread articles" in the toolbar.

The shortcut isn't visible when "All unread items" and "Starred items" is open, because they ignore that option.

This was discussed in #1026. 

Screenshot: 
<img src="https://github.com/nextcloud/news-android/assets/18418792/d6fd7524-4598-47bc-a2fa-e501855cd247" width="300px"/>