### PR TITLE
Allow searching both title and body at the same time

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/Search.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/Search.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import de.luhmer.owncloudnewsreader.SettingsActivity;
@@ -15,7 +17,8 @@ public class Search {
 
     private static final String SEARCH_IN_TITLE = "0";
     private static final String SEARCH_IN_BODY = "1";
-    
+    private static final String SEARCH_IN_BOTH = "2";
+
     public static List<RssItem> PerformSearch(Context context, Long idFolder, Long idFeed, String searchString, SharedPreferences mPrefs) {
         DatabaseConnectionOrm.SORT_DIRECTION sortDirection = DatabaseUtilsKt.getSortDirectionFromSettings(mPrefs);
         DatabaseConnectionOrm dbConn = new DatabaseConnectionOrm(context);
@@ -48,6 +51,8 @@ public class Search {
             sql = dbConn.getAllItemsIdsForFeedSQLFilteredByTitle(idFeed, false, false, sortDirection, searchString);
         } else if(searchIn.equals(SEARCH_IN_BODY)) {
             sql = dbConn.getAllItemsIdsForFeedSQLFilteredByBodySQL(idFeed, false, false, sortDirection, searchString);
+        } else if (searchIn.equals(SEARCH_IN_BOTH)) {
+            sql = dbConn.getAllItemsIdsForFeedSQLFilteredByTitleAndBodySQL(idFeed, false, false, sortDirection, searchString);
         }
         return sql;
     }
@@ -60,9 +65,12 @@ public class Search {
         String sql = "";
         String searchIn = mPrefs.getString(SettingsActivity.SP_SEARCH_IN,"0");
         if(searchIn.equals(SEARCH_IN_TITLE)) {
-            sql = dbConn.getAllItemsIdsForFolderSQLSearch(ID_FOLDER, sortDirection, RssItemDao.Properties.Title.columnName, searchString);
+            sql = dbConn.getAllItemsIdsForFolderSQLSearch(ID_FOLDER, sortDirection, Collections.singletonList(RssItemDao.Properties.Title.columnName), searchString);
         } else if(searchIn.equals(SEARCH_IN_BODY)) {
-            sql = dbConn.getAllItemsIdsForFolderSQLSearch(ID_FOLDER, sortDirection, RssItemDao.Properties.Body.columnName, searchString);
+            sql = dbConn.getAllItemsIdsForFolderSQLSearch(ID_FOLDER, sortDirection, Collections.singletonList(RssItemDao.Properties.Body.columnName), searchString);
+        } else if(searchIn.equals(SEARCH_IN_BOTH)) {
+            var columns = Arrays.asList(RssItemDao.Properties.Body.columnName, RssItemDao.Properties.Title.columnName);
+            sql = dbConn.getAllItemsIdsForFolderSQLSearch(ID_FOLDER, sortDirection, columns, searchString);
         }
 
         return sql;

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/Search.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/Search.java
@@ -46,7 +46,7 @@ public class Search {
                                        final DatabaseConnectionOrm dbConn,
                                        final SharedPreferences mPrefs) {
         String sql = "";
-        String searchIn = mPrefs.getString(SettingsActivity.SP_SEARCH_IN,"0");
+        String searchIn = mPrefs.getString(SettingsActivity.SP_SEARCH_IN, SEARCH_IN_BOTH); 
         if(searchIn.equals(SEARCH_IN_TITLE)) {
             sql = dbConn.getAllItemsIdsForFeedSQLFilteredByTitle(idFeed, false, false, sortDirection, searchString);
         } else if(searchIn.equals(SEARCH_IN_BODY)) {
@@ -63,7 +63,7 @@ public class Search {
                                          final DatabaseConnectionOrm dbConn,
                                          final SharedPreferences mPrefs) {
         String sql = "";
-        String searchIn = mPrefs.getString(SettingsActivity.SP_SEARCH_IN,"0");
+        String searchIn = mPrefs.getString(SettingsActivity.SP_SEARCH_IN, SEARCH_IN_BOTH);
         if(searchIn.equals(SEARCH_IN_TITLE)) {
             sql = dbConn.getAllItemsIdsForFolderSQLSearch(ID_FOLDER, sortDirection, Collections.singletonList(RssItemDao.Properties.Title.columnName), searchString);
         } else if(searchIn.equals(SEARCH_IN_BODY)) {

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -184,14 +184,15 @@
     <string name="pref_general_search_in_both">Both</string>
 
     <string-array name="pref_general_search_in" translatable="false">
+        <item>@string/pref_general_search_in_both</item>
         <item>@string/pref_general_search_in_title</item>
         <item>@string/pref_general_search_in_body</item>
-        <item>@string/pref_general_search_in_both</item>
     </string-array>
     <string-array name="pref_general_search_in_values" translatable="false">
+        <!-- The ordering here is weird as to not break users current setting -->
+        <item>2</item>
         <item>0</item>
         <item>1</item>
-        <item>2</item>
     </string-array>
 
 

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -181,14 +181,17 @@
 
     <string name="pref_general_search_in_title">Title</string>
     <string name="pref_general_search_in_body">Body</string>
+    <string name="pref_general_search_in_both">Both</string>
 
     <string-array name="pref_general_search_in" translatable="false">
         <item>@string/pref_general_search_in_title</item>
         <item>@string/pref_general_search_in_body</item>
+        <item>@string/pref_general_search_in_both</item>
     </string-array>
     <string-array name="pref_general_search_in_values" translatable="false">
         <item>0</item>
         <item>1</item>
+        <item>2</item>
     </string-array>
 
 

--- a/News-Android-App/src/main/res/xml/pref_general.xml
+++ b/News-Android-App/src/main/res/xml/pref_general.xml
@@ -113,9 +113,10 @@
             android:key="sp_sort_order"
             android:title="@string/pref_title_general_sort_order"
             app:iconSpaceReserved="false"/>
-
+    
+    	<!-- Default is BOTH(2) -->
         <ListPreference
-            android:defaultValue="0"
+	    android:defaultValue="2" 
             android:entries="@array/pref_general_search_in"
             android:entryValues="@array/pref_general_search_in_values"
             android:key="sp_search_in"


### PR DESCRIPTION
This PR adds option `Both` to `Search In`, allowing users to search through both title and body of articles at the same time.  

This closes #1263 

Implementation details:
1. Added private helper function `getSearchSQLForColumn` in `DatabaseConnectionOrm` to reduce code duplication.
2.  Changed `getAllItemsIdsForFolderSQLSearch` to take a list of `columns` to make the function more flexible and to minimize code duplication.
3. Added new string value `pref_general_search_in_both`


_Note: Translations are missing_