### PR TITLE
per-feed open-in settings

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -1172,8 +1172,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 					openRssItemInExternalBrowser(currentUrl);
 					break;
 				default:
-					Log.e("NRLA", "openIn has illegal value");
-					break;
+					throw new RuntimeException("Unreachable: openIn has illegal value " + openIn);
 			}
 		}
 	}

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -1133,34 +1133,76 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 	@Override
 	public void onClick(RssItemViewHolder vh, int position) {
+		Feed feed = vh.getRssItem().getFeed();
+		Long openIn	= feed.getOpenIn();
 
-		if (mPrefs.getBoolean(SettingsActivity.CB_SKIP_DETAILVIEW_AND_OPEN_BROWSER_DIRECTLY_STRING, false)) {
-			String currentUrl = vh.getRssItem().getLink();
+		Uri currentUrl = Uri.parse(vh.getRssItem().getLink());
 
-			//Choose Browser based on user settings
-			//modified copy from NewsDetailFragment.java:loadUrl(String url)
-			int selectedBrowser = Integer.parseInt(mPrefs.getString(SettingsActivity.SP_DISPLAY_BROWSER, "0"));
-			if (selectedBrowser == 0) { // Custom Tabs
-				CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder()
-						.setShowTitle(true)
-						.setStartAnimations(this, R.anim.slide_in_right, R.anim.slide_out_left)
-						.setExitAnimations(this, R.anim.slide_in_left, R.anim.slide_out_right)
-						.addDefaultShareMenuItem();
-				builder.build().launchUrl(this, Uri.parse(currentUrl));
-			} else { //External browser
-				Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(currentUrl));
-				startActivity(browserIntent);
+		if (openIn == null) {
+			if (mPrefs.getBoolean(SettingsActivity.CB_SKIP_DETAILVIEW_AND_OPEN_BROWSER_DIRECTLY_STRING, false)) {
+
+				//Choose Browser based on user settings
+				//modified copy from NewsDetailFragment.java:loadUrl(String url)
+				int selectedBrowser = Integer.parseInt(mPrefs.getString(SettingsActivity.SP_DISPLAY_BROWSER, "0"));
+				switch(selectedBrowser) {
+					case 0:
+						openRssItemInCustomTab(currentUrl);
+						break;
+					case 1:
+						//openRssItemInInternalBrowser(currentUrl);
+						break;
+					case 2:
+						openRssItemInExternalBrowser(currentUrl);
+						break;
+				}
+
+				((NewsListRecyclerAdapter) getNewsReaderDetailFragment().getRecyclerView().getAdapter()).changeReadStateOfItem(vh, true);
+			} else {
+				openRssItemInDetailedView(position);
 			}
-
-			((NewsListRecyclerAdapter) getNewsReaderDetailFragment().getRecyclerView().getAdapter()).changeReadStateOfItem(vh, true);
 		} else {
-			Intent intentNewsDetailAct = new Intent(this, NewsDetailActivity.class);
-
-			intentNewsDetailAct.putExtra(NewsReaderListActivity.ITEM_ID, position);
-			intentNewsDetailAct.putExtra(NewsReaderListActivity.TITLE, getNewsReaderDetailFragment().getTitle());
-			startActivityForResult(intentNewsDetailAct, Activity.RESULT_CANCELED);
+			switch (openIn.intValue()) {
+				case 1:
+					openRssItemInDetailedView(position);
+					break;
+				case 2:
+					openRssItemInCustomTab(currentUrl);
+					break;
+				case 3:
+					openRssItemInExternalBrowser(currentUrl);
+					break;
+				default:
+					Log.e("NRLA", "openIn has illegal value");
+					break;
+			}
 		}
 	}
+
+	private void openRssItemInDetailedView(int position) {
+		Intent intentNewsDetailAct = new Intent(this, NewsDetailActivity.class);
+
+		intentNewsDetailAct.putExtra(NewsReaderListActivity.ITEM_ID, position);
+		intentNewsDetailAct.putExtra(NewsReaderListActivity.TITLE, getNewsReaderDetailFragment().getTitle());
+		startActivityForResult(intentNewsDetailAct, Activity.RESULT_CANCELED);
+	}
+
+	private void openRssItemInCustomTab(Uri currentUrl) {
+		CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder()
+				.setShowTitle(true)
+				.setStartAnimations(this, R.anim.slide_in_right, R.anim.slide_out_left)
+				.setExitAnimations(this, R.anim.slide_in_left, R.anim.slide_out_right)
+				.setShareState(CustomTabsIntent.SHARE_STATE_ON);
+		builder.build().launchUrl(this, currentUrl);
+	}
+
+	private void openRssItemInExternalBrowser(Uri currentUrl) {
+		Intent browserIntent = new Intent(Intent.ACTION_VIEW, currentUrl);
+		startActivity(browserIntent);
+	}
+
+	// private void openRssItemInInternalBrowser(Uri currentUrl) {
+	// 	getNewsReaderDetailFragment().binding.webview.loadUrl(currentUrl.toString());
+	// }
 
 	@Override
 	public boolean onLongClick(RssItemViewHolder vh, int position) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -81,6 +82,8 @@ public class NewsReaderListDialogFragment extends DialogFragment {
         mMenuItems.put(getString(R.string.action_feed_move), () -> showMoveFeedView(mFeedId));
 
         mMenuItems.put(getString(R.string.action_feed_notification_settings), () -> showNotificationSettingsView(mFeedId));
+
+        mMenuItems.put(getString(R.string.action_feed_open_in), () -> showOpenSettingsView(mFeedId));
 
         setStyle(DialogFragment.STYLE_NO_TITLE, R.style.FloatingDialog);
     }
@@ -280,6 +283,48 @@ public class NewsReaderListDialogFragment extends DialogFragment {
         });
     }
 
+    private void showOpenSettingsView(final long feedId) {
+        binding.lvMenuList.setVisibility(View.GONE);
+        binding.openFeedDialog.setVisibility(View.VISIBLE);
+
+        DatabaseConnectionOrm dbConn = new DatabaseConnectionOrm(getContext());
+        Feed feed = dbConn.getFeedById(feedId);
+        Long openIn = feed.getOpenIn();
+
+        binding.openInUseGeneralSetting.setChecked(false);
+        binding.openInDetailedView.setChecked(false);
+        binding.openInBrowserCct.setChecked(false);
+        binding.openInBrowserExternal.setChecked(false);
+
+        if (openIn == null) {
+            binding.openInUseGeneralSetting.setChecked(true);
+        } else {
+            switch (openIn.intValue()) {
+                case 1:
+                    binding.openInDetailedView.setChecked(true);
+                    break;
+                case 2:
+                    binding.openInBrowserCct.setChecked(true);
+                    break;
+                case 3:
+                    binding.openInBrowserExternal.setChecked(true);
+                    break;
+                default:
+                    Log.e("NRLDF", "openIn has illegal value: " + openIn);
+                    break;
+            }
+        }
+
+        binding.openInUseGeneralSetting.setOnCheckedChangeListener((button, checked)
+                -> setOpenInForFeed(feed, null, checked));
+        binding.openInDetailedView.setOnCheckedChangeListener((button, checked)
+                -> setOpenInForFeed(feed, 1L, checked));
+        binding.openInBrowserCct.setOnCheckedChangeListener((button, checked)
+                -> setOpenInForFeed(feed, 2L, checked));
+        binding.openInBrowserExternal.setOnCheckedChangeListener((button, checked)
+                -> setOpenInForFeed(feed, 3L, checked));
+    }
+
     private void showNotificationSettingsView(final long feedId) {
         binding.lvMenuList.setVisibility(View.GONE);
         binding.notificationFeedDialog.setVisibility(View.VISIBLE);
@@ -311,6 +356,14 @@ public class NewsReaderListDialogFragment extends DialogFragment {
         binding.notificationSettingUnique.setOnCheckedChangeListener((button, checked) ->
                 // Use the feed name as notification channel name
                 setNotificationChannelForFeed(feed, feed.getFeedTitle(), checked));
+    }
+
+    private void setOpenInForFeed(Feed feed, Long openIn, Boolean checked) {
+        if (checked) {
+            feed.setOpenIn(openIn);
+            feed.update();
+            this.showOpenSettingsView(feed.getId()); // reload dialog
+        }
     }
 
     private void setNotificationChannelForFeed(Feed feed, String channel, Boolean checked) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java
@@ -310,8 +310,7 @@ public class NewsReaderListDialogFragment extends DialogFragment {
                     binding.openInBrowserExternal.setChecked(true);
                     break;
                 default:
-                    Log.e("NRLDF", "openIn has illegal value: " + openIn);
-                    break;
+                    throw new RuntimeException("Unreachable: openIn has illegal value " + openIn);
             }
         }
 

--- a/News-Android-App/src/main/res/layout/fragment_dialog_feedoptions.xml
+++ b/News-Android-App/src/main/res/layout/fragment_dialog_feedoptions.xml
@@ -220,6 +220,39 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/open_feed_dialog"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/horizontalDivider"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/open_in_use_general_setting"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/action_feed_open_in_general_setting" />
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/open_in_detailed_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/action_feed_open_in_detailed_view" />
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/open_in_browser_cct"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/pref_display_browser_cct" />
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/open_in_browser_external"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/pref_display_browser_external" />
+    </LinearLayout>
+
     <RelativeLayout
         android:id="@+id/progressView"
         android:layout_width="match_parent"

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -90,11 +90,15 @@
     <string name="action_feed_rename">Rename Feed</string>
     <string name="action_feed_move">Move Feed</string>
     <string name="action_feed_notification_settings">Notification settings</string>
+    <string name="action_feed_open_in">Open-in settings</string>
+    <string name="action_feed_open_in_general_setting">Use general setting</string>
+    <string name="action_feed_open_in_detailed_view">Detailed view</string>
     <string name="feed_remove_button">Remove</string>
     <string name="feed_rename_button">Rename</string>
     <string name="confirm_feed_remove">Do you really want to remove this Feed? This cannot be undone!</string>
     <string name="feed_move_list_description">Select folder to move feed in</string>
     <string name="move_feed_root_folder">Root folder</string>
+
 
     <!-- Strings related to FolderOptionsDialogFragment (Rename/Remove folder) -->
     <string name="action_folder_remove">Remove folder</string>


### PR DESCRIPTION
This adds a "Open-in settings" when long-pressing on a feed, allowing users to specify how a feed is opened.

This _was_ a __draft__ because:
1. ~Internal Browser isn't a option yet.~ This is marked unnecessary as `Chrome-Custom-Tags` is basically the same thing. (see https://github.com/nextcloud/news-android/pull/1266#issuecomment-1733727181) 
2. ~The option isn't persistent. Unsure why, it's stored in the database but it's always read back as `null`?~ This has been fixed thanks to David! (https://github.com/nextcloud/news-android/commit/f850ad2951c01bf52fd1df3238bef926d5e4ed18)
3. ~Unsure what a good tag [here](https://github.com/mkanilsson/news-android/blob/per-feed-open-settings/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java#L313) is.~ This has been fixed by using a RuntimeException instead.

Closes #1221,  #1058 and #957. 

__Preview__

https://github.com/nextcloud/news-android/assets/18418792/a5a9b978-f1ad-4989-a7d6-fd35c00cd6c1

