### PR TITLE
Add "remove podcast" in toolbar and "Downloaded podcasts" special folder

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ListView/PodcastArrayAdapter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ListView/PodcastArrayAdapter.java
@@ -57,7 +57,7 @@ public class PodcastArrayAdapter extends ArrayAdapter<PodcastItem> {
         });
 
         holder.binding.flDeletePodcastWrapper.setOnClickListener(view13 -> {
-            if(NewsFileUtils.deletePodcastFile(getContext(), podcastItem.link)) {
+            if(NewsFileUtils.deletePodcastFile(getContext(), podcastItem.fingerprint, podcastItem.link)) {
                 podcastItem.offlineCached = false;
                 podcastItem.downloadProgress = PodcastItem.DOWNLOAD_NOT_STARTED;
                 notifyDataSetChanged();

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
@@ -405,7 +405,7 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 		}
 
 		if(menuItem_RemovePodcast != null) {
-			File file = new File(PodcastDownloadService.getUrlToPodcastFile(this, podcastItem.link, false));
+			File file = new File(PodcastDownloadService.getUrlToPodcastFile(this, podcastItem.fingerprint, podcastItem.link, false));
 			menuItem_RemovePodcast.setVisible(file.exists());
 		}
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
@@ -49,6 +49,7 @@ import androidx.fragment.app.FragmentStatePagerAdapter;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
 
+import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.HashSet;
 import java.util.Set;
@@ -63,6 +64,7 @@ import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
 import de.luhmer.owncloudnewsreader.helper.ThemeUtils;
 import de.luhmer.owncloudnewsreader.model.PodcastItem;
 import de.luhmer.owncloudnewsreader.model.TTSItem;
+import de.luhmer.owncloudnewsreader.services.PodcastDownloadService;
 import de.luhmer.owncloudnewsreader.view.PodcastSlidingUpPanelLayout;
 import de.luhmer.owncloudnewsreader.widget.WidgetProvider;
 
@@ -90,6 +92,7 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 	private int currentPosition;
 
 	private MenuItem menuItem_PlayPodcast;
+	private MenuItem menuItem_RemovePodcast;
 	private MenuItem menuItem_Starred;
 	private MenuItem menuItem_Read;
 	private MenuItem menuItem_Incognito;
@@ -401,6 +404,11 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 			menuItem_PlayPodcast.setVisible(podcastAvailable);
 		}
 
+		if(menuItem_RemovePodcast != null) {
+			File file = new File(PodcastDownloadService.getUrlToPodcastFile(this, podcastItem.link, false));
+			menuItem_RemovePodcast.setVisible(file.exists());
+		}
+
 		if (menuItem_Starred != null) {
 			int res = isStarred ? R.drawable.ic_star_24_theme_aware : R.drawable.ic_star_border_24dp_theme_aware;
 			menuItem_Starred.setIcon(res);
@@ -442,6 +450,7 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 		menuItem_Starred = menu.findItem(R.id.action_starred);
 		menuItem_Read = menu.findItem(R.id.action_read);
 		menuItem_PlayPodcast = menu.findItem(R.id.action_playPodcast);
+		menuItem_RemovePodcast = menu.findItem(R.id.action_removePodcast);
 		menuItem_Incognito = menu.findItem(R.id.action_incognito_mode);
 
 		if (mShowFastActions) {
@@ -493,6 +502,12 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 			this.openInBrowser(currentPosition);
 		} else if (itemId == R.id.action_playPodcast) {
 			openPodcast(rssItem);
+		} else if (itemId == R.id.action_removePodcast) {
+			removePodcastMedia(rssItem, (result) -> {
+				if (menuItem_RemovePodcast != null) {
+					menuItem_RemovePodcast.setVisible(!result);
+				}
+			});
 		} else if (itemId == R.id.action_tts) {
 			this.startTTS(currentPosition);
 		} else if (itemId == R.id.action_ShareItem) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -746,6 +746,8 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 				title = getString(R.string.allUnreadFeeds);
 			} else if (idFolder == -11) {
 				title = getString(R.string.starredFeeds);
+			} else if (idFolder == -13) {
+				title = getString(R.string.downloadedPodcasts);
 			}
 		} else {
 			Feed feed = dbConn.getFeedById(id);
@@ -834,6 +836,8 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 				title = getString(R.string.allUnreadFeeds);
 			} else if (idFolder == -11) {
 				title = getString(R.string.starredFeeds);
+			} else if (idFolder == -13) {
+				title = getString(R.string.downloadedPodcasts);
 			}
 		}
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
@@ -182,7 +182,7 @@ public class PodcastFragment extends Fragment {
 
                     if (downloadProgress.podcast.downloadProgress == 100) {
                         pItem.downloadProgress = PodcastItem.DOWNLOAD_COMPLETED;
-                        File file = new File(PodcastDownloadService.getUrlToPodcastFile(getActivity(), pItem.link, false));
+                        File file = new File(PodcastDownloadService.getUrlToPodcastFile(getActivity(), pItem.fingerprint, pItem.link, false));
                         pItem.offlineCached = file.exists();
                     } else
                         pItem.downloadProgress = downloadProgress.podcast.downloadProgress;

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
@@ -295,7 +295,7 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
     public void openPodcast(final RssItem rssItem) {
         final PodcastItem podcastItem = DatabaseConnectionOrm.ParsePodcastItemFromRssItem(this, rssItem);
 
-        File file = new File(PodcastDownloadService.getUrlToPodcastFile(this, podcastItem.link, false));
+        File file = new File(PodcastDownloadService.getUrlToPodcastFile(this, podcastItem.fingerprint, podcastItem.link, false));
         if(file.exists()) {
             podcastItem.link = file.getAbsolutePath();
             openMediaItem(podcastItem);
@@ -322,7 +322,7 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
 
     public void removePodcastMedia(final RssItem rssItem, final Consumer<Boolean> callback) {
         final PodcastItem podcastItem = DatabaseConnectionOrm.ParsePodcastItemFromRssItem(this, rssItem);
-        File file = new File(PodcastDownloadService.getUrlToPodcastFile(this, podcastItem.link, false));
+        File file = new File(PodcastDownloadService.getUrlToPodcastFile(this, podcastItem.fingerprint, podcastItem.link, false));
 
         if (!file.exists()) {
             callback.accept(true);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
@@ -28,6 +28,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
 import java.io.File;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -316,6 +317,35 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
 
             alertDialog.show();
         }
+    }
+
+
+    public void removePodcastMedia(final RssItem rssItem, final Consumer<Boolean> callback) {
+        final PodcastItem podcastItem = DatabaseConnectionOrm.ParsePodcastItemFromRssItem(this, rssItem);
+        File file = new File(PodcastDownloadService.getUrlToPodcastFile(this, podcastItem.link, false));
+
+        if (!file.exists()) {
+            callback.accept(true);
+        }
+
+        AlertDialog.Builder alertDialog = new AlertDialog.Builder(this)
+                .setNegativeButton("Remove", (dialogInterface, i) -> {
+                    boolean success = file.delete() && file.getParentFile().delete(); // remove audio file and parent folder
+                    if (!success) {
+                        Toast.makeText(PodcastFragmentActivity.this, "Failed to remove media for \"" + podcastItem.title + "\"", Toast.LENGTH_SHORT).show();
+                    } else {
+                        Toast.makeText(PodcastFragmentActivity.this, "Media for \"" + podcastItem.title + "\" has been removed", Toast.LENGTH_SHORT).show();
+                    }
+
+                    callback.accept(success);
+                })
+                .setNeutralButton("Cancel", (dialogInterface, i) -> {
+                    callback.accept(false);
+                })
+                .setTitle("Are you sure?")
+                .setMessage("Do you want to remove downloaded media for \"" + podcastItem.title + "?\"");
+
+        alertDialog.show();
     }
 
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/RssItemViewHolder.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/RssItemViewHolder.java
@@ -352,7 +352,7 @@ public abstract class RssItemViewHolder<T extends ViewBinding> extends RecyclerV
 
     public void setDownloadPodcastProgressbar() {
         float progress;
-        if (PodcastDownloadService.PodcastAlreadyCached(itemView.getContext(), rssItem.getEnclosureLink())) {
+        if (PodcastDownloadService.PodcastAlreadyCached(itemView.getContext(), rssItem.getFingerprint(), rssItem.getEnclosureLink())) {
             progress = 100;
         } else {
             progress = downloadProgressList.get(rssItem.getId().intValue(), 0);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/NewsFileUtils.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/NewsFileUtils.java
@@ -31,6 +31,10 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import de.luhmer.owncloudnewsreader.services.DownloadWebPageService;
 import de.luhmer.owncloudnewsreader.services.PodcastDownloadService;
@@ -73,9 +77,9 @@ public class NewsFileUtils {
     }
 
 
-    public static boolean deletePodcastFile(Context context, String url) {
+    public static boolean deletePodcastFile(Context context, String fingerprint, String url) {
         try {
-            File file = new File(PodcastDownloadService.getUrlToPodcastFile(context, url, false));
+            File file = new File(PodcastDownloadService.getUrlToPodcastFile(context, fingerprint, url, false));
             if(file.exists())
                 return file.delete();
         } catch (Exception ex) {
@@ -234,6 +238,16 @@ public class NewsFileUtils {
                 throw new IOException(message);
             }
         }
+    }
+
+    public static String[] getDownloadedPodcastsFingerprints(Context context) {
+        File folder = new File(NewsFileUtils.getPathPodcasts(context));
+        File[] files = folder.listFiles();
+        if (files == null) {
+            return new String[0];
+        }
+        List<String> ids = Arrays.stream(files).map(File::getName).collect(Collectors.toList());
+        return ids.toArray(new String[0]);
     }
 
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/model/PodcastItem.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/model/PodcastItem.java
@@ -6,7 +6,7 @@ public class PodcastItem extends MediaItem {
 
     }
 
-    public PodcastItem(long itemId, String author, String title, String link, String mimeType, boolean offlineCached, String favIcon, boolean isVideoPodcast) {
+    public PodcastItem(long itemId, String author, String title, String link, String mimeType, boolean offlineCached, String favIcon, boolean isVideoPodcast, String fingerprint) {
         this.itemId = itemId;
         this.author = author;
         this.title = title;
@@ -15,9 +15,11 @@ public class PodcastItem extends MediaItem {
         this.offlineCached = offlineCached;
         this.favIcon = favIcon;
         this.isVideoPodcast = isVideoPodcast;
+        this.fingerprint = fingerprint;
     }
 
     public String mimeType;
+    public String fingerprint;
     public boolean offlineCached;
     public boolean isVideoPodcast;
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastDownloadService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastDownloadService.java
@@ -93,7 +93,7 @@ public class PodcastDownloadService extends IntentService {
         request.allowScanningByMediaScanner();
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
 
-        String path = "file://" + getUrlToPodcastFile(this, podcast.link, true);
+        String path = "file://" + getUrlToPodcastFile(this, podcast.fingerprint, podcast.link, true);
         request.setDestinationUri(Uri.parse(path));
         //request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, "bla.txt");
 
@@ -103,32 +103,15 @@ public class PodcastDownloadService extends IntentService {
     }
 
 
-    public static String getUrlToPodcastFile(Context context, String WEB_URL_TO_FILE, boolean createDir) {
+    public static String getUrlToPodcastFile(Context context, String fingerprint, String WEB_URL_TO_FILE, boolean createDir) {
         File file = new File(WEB_URL_TO_FILE);
 
-        String path = NewsFileUtils.getPathPodcasts(context) + "/" + getHashOfString(WEB_URL_TO_FILE) + "/";
+        String path = NewsFileUtils.getPathPodcasts(context) + "/" + fingerprint + "/";
         if(createDir)
             new File(path).mkdirs();
 
         return path + file.getName();
     }
-
-    public static String getHashOfString(String WEB_URL_TO_FILE)
-    {
-        try {
-            MessageDigest m = MessageDigest.getInstance("MD5");
-            m.reset();
-            m.update(WEB_URL_TO_FILE.trim().getBytes());
-            byte[] digest = m.digest();
-            BigInteger bigInt = new BigInteger(1,digest);
-
-            return bigInt.toString(16);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return WEB_URL_TO_FILE;
-    }
-
 
     private void downloadPodcast(PodcastItem podcast, Context context) {
 
@@ -141,7 +124,7 @@ public class PodcastDownloadService extends IntentService {
 
         try {
             String urlTemp = podcast.link;
-            String path = getUrlToPodcastFile(this, urlTemp, true);
+            String path = getUrlToPodcastFile(this, podcast.fingerprint, urlTemp, true);
             Log.v(TAG, "Storing podcast to: " + path);
 
             URL url = new URL(urlTemp);
@@ -242,8 +225,8 @@ public class PodcastDownloadService extends IntentService {
         public PodcastItem podcast;
     }
 
-    public static boolean PodcastAlreadyCached(Context context, String podcastUrl) {
-        File file = new File(PodcastDownloadService.getUrlToPodcastFile(context, podcastUrl, false));
+    public static boolean PodcastAlreadyCached(Context context, String podcastFingerprint, String podcastUrl) {
+        File file = new File(PodcastDownloadService.getUrlToPodcastFile(context, podcastFingerprint, podcastUrl, false));
         return file.exists();
     }
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
@@ -339,7 +339,7 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
     private void updateMetadata(MediaItem mediaItem) {
         MediaItem mi = mediaItem;
         if(mi == null) {
-            mi = new PodcastItem(-1, "", "", "", "", false, null, false);
+            mi = new PodcastItem(-1, "", "", "", "", false, null, false, "");
         }
 
         int totalDuration = 0;

--- a/News-Android-App/src/main/res/drawable/ic_action_delete_24_theme_aware.xml
+++ b/News-Android-App/src/main/res/drawable/ic_action_delete_24_theme_aware.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:tint="?attr/colorControlNormal"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
+</vector>

--- a/News-Android-App/src/main/res/menu/news_detail.xml
+++ b/News-Android-App/src/main/res/menu/news_detail.xml
@@ -29,6 +29,12 @@
         android:title="@string/action_openInBrowser"/>
 
     <item
+        android:id="@+id/action_removePodcast"
+        app:showAsAction="always"
+        android:icon="@drawable/ic_action_delete_24_theme_aware"
+        android:title="@string/action_removePodcast"/>
+
+    <item
         android:id="@+id/action_playPodcast"
         app:showAsAction="always"
         android:icon="@drawable/ic_baseline_play_arrow_24_theme_aware"

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="action_starred">Starred</string>
     <string name="action_read">Read</string>
     <string name="action_playPodacst">Play Podcast</string>
+    <string name="action_removePodcast">Remove Podcast Media</string>
     <string name="action_openInBrowser">Open in Web browser</string>
     <string name="action_Share">Share</string>
     <string name="action_login">Server Settings</string>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="message_bar_reload">Reload</string>
     <string name="allUnreadFeeds">All unread items</string>
     <string name="starredFeeds">Starred items</string>
+    <string name="downloadedPodcasts">Downloaded podcasts</string>
     <string name="title_activity_new_feed">Add new feed</string>
 
     <string name="menu_update">Refresh</string>


### PR DESCRIPTION
This PR adds 1. a trashcan icon in the toolbar when in a podcast and 2. a special `Downloaded Podcasts` in the sidebar.

This is a __draft__ because:
1. The UI doesn't update and adds the trashcan icon when a podcast has been downloaded.
2. I can't manage to get the number of downloaded podcasts to show up in the sidebar.

> NOTE: This is a breaking change which makes users unable to play their already downloaded podcasts, the reasons for this is: Before, the media was stored in `md5_hashed_url/filename` but since sqlite doesn't have a `MD5` function I had to change the path to `rss_item_fingerprint/filename` so I can use a `fingerprint in (ids)` query and get all downloaded podcasts

Once this is done, it will close #742 

https://github.com/nextcloud/news-android/assets/18418792/aa9afc91-99f1-4e63-a23e-07437d18a115

