### PR TITLE
use okhttp client for caching (instead of glide)

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -150,6 +150,7 @@ dependencies {
 
     implementation "com.github.bumptech.glide:glide:${GLIDE_VERSION}"
     ksp "com.github.bumptech.glide:ksp:${GLIDE_VERSION}"
+    implementation "com.github.bumptech.glide:okhttp3-integration:4.16.0"
     debugImplementation "com.github.technoir42:glide-debug-indicator:0.9.1"
     implementation 'com.caverock:androidsvg-aar:1.4'
 

--- a/News-Android-App/proguard-rules.pro
+++ b/News-Android-App/proguard-rules.pro
@@ -112,6 +112,8 @@
 -keep,allowobfuscation,allowshrinking class io.reactivex.rxjava3.core.Observable
 -keep,allowobfuscation,allowshrinking class io.reactivex.rxjava3.core.Single
 
+# glide
+-keep class com.bumptech.glide.integration.okhttp.OkHttpGlideModule
 
 
 

--- a/News-Android-App/src/main/AndroidManifest.xml
+++ b/News-Android-App/src/main/AndroidManifest.xml
@@ -29,10 +29,15 @@
         android:usesCleartextTraffic="true"
         tools:replace="android:icon, android:label, android:theme, android:name">
 
-        <meta-data android:name="com.google.android.gms.car.application"
-            android:resource="@xml/automotive_app_desc"/>
-        <meta-data android:name="com.google.android.gms.car.notification.SmallIcon"
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+        <meta-data
+            android:name="com.google.android.gms.car.notification.SmallIcon"
             android:resource="@drawable/ic_notification" />
+        <meta-data
+            android:name="com.bumptech.glide.integration.okhttp.OkHttpGlideModule"
+            android:value="GlideModule" />
 
         <activity
             android:name=".NewsReaderListActivity"

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -63,7 +63,6 @@ import androidx.preference.PreferenceManager;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.google.android.material.snackbar.Snackbar;
 import com.nextcloud.android.sso.AccountImporter;
 import com.nextcloud.android.sso.api.NextcloudAPI;
@@ -592,7 +591,6 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 			Glide.with(this)
 					.load(avatarUrl)
-					.diskCacheStrategy(DiskCacheStrategy.DATA)
 					.placeholder(placeHolder)
 					.error(placeHolder)
 					.circleCrop()

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/RssItemHeadlineThumbnailViewHolder.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/RssItemHeadlineThumbnailViewHolder.java
@@ -13,7 +13,6 @@ import androidx.annotation.NonNull;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
 import com.bumptech.glide.load.MultiTransformation;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.bitmap.CenterCrop;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 
@@ -94,7 +93,7 @@ public class RssItemHeadlineThumbnailViewHolder extends RssItemViewHolder<Subscr
 
             mGlide
                     .load(mediaThumbnail)
-                    .diskCacheStrategy(DiskCacheStrategy.DATA)
+                    // .diskCacheStrategy(DiskCacheStrategy.DATA) // use okhttp caching
                     .placeholder(feedIcon)
                     .error(feedIcon)
                     .transform(new MultiTransformation<>(new CenterCrop(), new RoundedCorners(60)))

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/RssItemThumbnailViewHolder.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/RssItemThumbnailViewHolder.java
@@ -15,7 +15,6 @@ import androidx.annotation.NonNull;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
 import com.bumptech.glide.load.MultiTransformation;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.bitmap.CenterCrop;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 
@@ -93,7 +92,7 @@ public class RssItemThumbnailViewHolder extends RssItemViewHolder<SubscriptionDe
 
             mGlide
                     .load(mediaThumbnail)
-                    .diskCacheStrategy(DiskCacheStrategy.DATA)
+                    // .diskCacheStrategy(DiskCacheStrategy.DATA) // use okhttp caching
                     .placeholder(feedIcon)
                     .error(feedIcon)
                     .transform(new MultiTransformation<>(new CenterCrop(), new RoundedCorners(60)))

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/async_tasks/DownloadImageHandler.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/async_tasks/DownloadImageHandler.java
@@ -25,7 +25,6 @@ import android.graphics.Bitmap;
 import android.util.Log;
 
 import com.bumptech.glide.RequestManager;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
 import java.net.URL;
 import java.util.concurrent.ExecutionException;
@@ -51,7 +50,7 @@ public class DownloadImageHandler {
 			Bitmap bm = glide
 					.asBitmap()
 					.load(mImageUrl.toString())
-					.diskCacheStrategy(DiskCacheStrategy.DATA)
+					// .diskCacheStrategy(DiskCacheStrategy.DATA) // use okhttp cache
 					.submit()
 					.get();
 			NotifyDownloadFinished(bm);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/async_tasks/RssItemToHtmlTask.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/async_tasks/RssItemToHtmlTask.java
@@ -290,9 +290,10 @@ public class RssItemToHtmlTask extends AsyncTask<Void, Void, String> {
             try {
                 File file = null;
                 try {
+                    // TODO!!!! THIS CODE BELOW DOESN'T WORK WITH OKHTTP!!
                     file = glide
                             .asFile()
-                            .diskCacheStrategy(DiskCacheStrategy.DATA)
+                            // .diskCacheStrategy(DiskCacheStrategy.DATA) // TODO!! NOT WORKING
                             .onlyRetrieveFromCache(true)
                             // .listener(rl)
                             .load(link)
@@ -313,7 +314,7 @@ public class RssItemToHtmlTask extends AsyncTask<Void, Void, String> {
         return text;
     }
 
-    private static RequestListener<File> rl = new RequestListener<>() {
+    private static final RequestListener<File> rl = new RequestListener<>() {
         @Override
         public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<File> target, boolean isFirstResource) {
             // Log the GlideException here (locally or with a remote logging framework):

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/di/ApiModule.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/di/ApiModule.java
@@ -1,5 +1,8 @@
 package de.luhmer.owncloudnewsreader.di;
 
+import static de.luhmer.owncloudnewsreader.helper.NextcloudGlideModuleKt.CACHE_SIZE;
+import static de.luhmer.owncloudnewsreader.helper.NextcloudGlideModuleKt.MB;
+
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -13,6 +16,7 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
+import de.luhmer.owncloudnewsreader.SettingsActivity;
 import de.luhmer.owncloudnewsreader.helper.PostDelayHandler;
 import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
 import de.luhmer.owncloudnewsreader.ssl.MemorizingTrustManager;
@@ -85,17 +89,35 @@ public class ApiModule {
 
     @Provides
     @Singleton
-    OkHttpClient provideOkHttpClient(Cache cache) {
-        // setCache(cache);
-        return new OkHttpClient();
-    }
-
-    @Provides
-    @Singleton
     PostDelayHandler providePostDelayHandler() {
         return new PostDelayHandler(mApplication);
     }
 
+
+    @Provides
+    @Singleton
+    OkHttpClient provideOkHttpClient(SharedPreferences prefs) {
+        String cacheSize = prefs.getString(SettingsActivity.SP_MAX_CACHE_SIZE, String.valueOf(CACHE_SIZE));
+        Long diskCacheSizeBytes = Long.valueOf(cacheSize) * MB;
+
+        OkHttpClient.Builder client = new OkHttpClient.Builder()
+                .cache(new Cache(mApplication.getApplicationContext().getCacheDir(), diskCacheSizeBytes));
+        /*
+                .addInterceptor(Interceptor { chain: Interceptor.Chain ->
+            val response = chain.proceed(chain.request())
+            if (response.cacheResponse != null) {
+                Log.d("NextcloudGlideModule", "cached response: " + response.request.url)
+            } else if (response.networkResponse != null) {
+                Log.d("NextcloudGlideModule", "network response: " + response.request.url)
+                for (h in response.request.headers) {
+                    Log.d("NextcloudGlideModule", "request headers: $h")
+                }
+            }
+            response
+        })
+         */
+        return client.build();
+    }
 
     /*
     @Provides

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ImageHandler.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ImageHandler.java
@@ -26,12 +26,15 @@ import android.util.Log;
 
 import com.bumptech.glide.Glide;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import okhttp3.OkHttpClient;
 
 public class ImageHandler {
     private static final String TAG = "[ImageHandler]";
@@ -192,18 +195,27 @@ public class ImageHandler {
     private static String getFileName(String url) {
         int idx = url.lastIndexOf("/");
         int countOfSlashes = url.split("/").length - 1;
-        if(idx > 0) {
+        if (idx > 0) {
             return url.substring(idx);
         } else {
             return url;
         }
     }
 
-    public static void clearCache(Context context)
-    {
+    public static void clearGlideCache(Context context) {
+        Glide.get(context).clearMemory(); // needs to run on main thread
         new Thread(() -> {
-            Glide.get(context).clearMemory();
             Glide.get(context).clearDiskCache();
+        }).start();
+    }
+
+    public static void clearOkHttpCache(OkHttpClient okHttpClient) {
+        new Thread(() -> {
+            try {
+                okHttpClient.cache().evictAll();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }).start();
     }
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/NextcloudGlideModule.kt
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/NextcloudGlideModule.kt
@@ -7,35 +7,51 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.GlideBuilder
 import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.engine.cache.InternalCacheDiskCacheFactory
+import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.module.AppGlideModule
+import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.samples.svg.SvgDecoder
 import com.bumptech.glide.samples.svg.SvgDrawableTranscoder
 import com.caverock.androidsvg.SVG
 import de.luhmer.owncloudnewsreader.NewsReaderApplication
-import de.luhmer.owncloudnewsreader.SettingsActivity
 import de.luhmer.owncloudnewsreader.di.ApiProvider
+import okhttp3.OkHttpClient
 import java.io.InputStream
 import javax.inject.Inject
 
-private const val CACHE_SIZE = 500
+const val CACHE_SIZE = 500
 
-private const val KB = 1024
-private const val MB = 1024 * KB
+const val KB = 1024
+const val MB = 1024 * KB
 
 @GlideModule
 class NextcloudGlideModule : AppGlideModule() {
 
     @Inject
-    lateinit var mApi: ApiProvider
+    lateinit var api: ApiProvider
 
     @Inject
-    lateinit var mPrefs: SharedPreferences
+    lateinit var prefs: SharedPreferences
+
+    @Inject
+    lateinit var okHttpClient: OkHttpClient
 
     override fun applyOptions(context: Context, builder: GlideBuilder) {
         super.applyOptions(context, builder)
         (context.applicationContext as NewsReaderApplication).appComponent.injectGlideModule(this)
-        val cacheSize = mPrefs.getString(SettingsActivity.SP_MAX_CACHE_SIZE, CACHE_SIZE.toString())
+        builder.setDefaultRequestOptions(
+            // caching is handled by OkHttp
+            RequestOptions().diskCacheStrategy(DiskCacheStrategy.NONE)
+        )
+
+        // glide cache is only used for favicons - thus is should only be around 10MB in size
+        builder.setDiskCache(InternalCacheDiskCacheFactory(context, (10 * MB).toLong()))
+
+        /*
+        val cacheSize = prefs.getString(SettingsActivity.SP_MAX_CACHE_SIZE, CACHE_SIZE.toString())
         val diskCacheSizeBytes = (cacheSize?.toInt() ?: CACHE_SIZE) * MB
 
         // Glide uses DiskLruCacheWrapper as the default DiskCache. DiskLruCacheWrapper is a fixed
@@ -54,6 +70,7 @@ class NextcloudGlideModule : AppGlideModule() {
         //         Drawable::class.java,
         //         DrawableTransitionOptions.with(DebugIndicatorTransitionFactory.DEFAULT)
         // )
+        */
     }
 
     override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
@@ -61,5 +78,11 @@ class NextcloudGlideModule : AppGlideModule() {
         registry
             .register(SVG::class.java, PictureDrawable::class.java, SvgDrawableTranscoder())
             .append(InputStream::class.java, SVG::class.java, SvgDecoder())
+
+        registry.replace(
+            GlideUrl::class.java,
+            InputStream::class.java,
+            OkHttpUrlLoader.Factory(okHttpClient)
+        )
     }
 }


### PR DESCRIPTION
This MR disables Glides Caching and uses OkHttp's caching instead. The reason is that Glide does not care about ETags and Last-Modified Headers. Once a URL is in the cache it stays there. See: https://github.com/bumptech/glide/issues/1847

Fixes https://github.com/nextcloud/news-android/issues/1247

**Changes:**
- Glide cache is now only 10mb as it is supposed to be used only for favicons
- Default `DiskCacheStrategy` is now `NONE` - only favicons override this setting 
- OkHttp has a Cache now (which has the size of what's configured in the app settings - by default 500mb)

**TODO:**
- Offline caching of images does not currently work (see todo in code)
- Injecting images into articles from cache currently does not work (as the cache check only checks the glide cache - not the okhttp cache)