### PR TITLE
Fix avatar placeholder renders white on white in light theme

### DIFF
--- a/News-Android-App/src/main/res/drawable/ic_baseline_account_circle_24.xml
+++ b/News-Android-App/src/main/res/drawable/ic_baseline_account_circle_24.xml
@@ -1,4 +1,4 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
+<vector android:height="24dp" android:tint="?colorOnSurfaceVariant"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,5c1.66,0 3,1.34 3,3s-1.34,3 -3,3 -3,-1.34 -3,-3 1.34,-3 3,-3zM12,19.2c-2.5,0 -4.71,-1.28 -6,-3.22 0.03,-1.99 4,-3.08 6,-3.08 1.99,0 5.97,1.09 6,3.08 -1.29,1.94 -3.5,3.22 -6,3.22z"/>


### PR DESCRIPTION
Icon color now matches those of action icons in all themes.

Tested with and without user avatars set in nextcloud.