### PR TITLE
Enable androids autofill service in login mask

### DIFF
--- a/News-Android-App/src/main/res/layout/activity_login_dialog.xml
+++ b/News-Android-App/src/main/res/layout/activity_login_dialog.xml
@@ -79,6 +79,7 @@
                     android:gravity="start"
                     android:hint="@string/pref_title_username"
                     android:inputType="textEmailAddress"
+                    android:autofillHints="emailAddress"
                     android:textAlignment="viewStart" />
 
             </com.google.android.material.textfield.TextInputLayout>
@@ -104,6 +105,7 @@
                     android:gravity="start"
                     android:hint="@string/pref_title_password"
                     android:inputType="textPassword"
+                    android:autofillHints="password"
                     android:maxLines="1"
                     android:singleLine="true"
                     android:textAlignment="viewStart" />


### PR DESCRIPTION
I just added invisible hints for the autofill service (see https://developer.android.com/guide/topics/text/autofill-optimize).
This allows password managers and other autofill service to pick up on these input fields and autofill the users credentials.