### PR TITLE
Fix lint for URLEncoder.encode which requires API 33

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsFragment.java
@@ -377,9 +377,13 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             }
         }
 
-        body = URLEncoder.encode(debugInfo, StandardCharsets.UTF_8);
-        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/nextcloud/news-android/issues/new?title=" + title + "&body=" + body));
-        startActivity(browserIntent);
+        try {
+            body = URLEncoder.encode(debugInfo, StandardCharsets.UTF_8.toString());
+            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/nextcloud/news-android/issues/new?title=" + title + "&body=" + body));
+            startActivity(browserIntent);
+        } catch (UnsupportedEncodingException e) {
+            // Should never happen for UTF8 on android
+        }
     }
 
 


### PR DESCRIPTION
Fixes following lint error:
```
  /home/runner/actions-runner/_work/news-android/news-android/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsFragment.java:380: Error: Call requires API level 33 (current min is 21): java.net.URLEncoder#encode [NewApi]
          body = URLEncoder.encode(debugInfo, StandardCharsets.UTF_8);
                            ~~~~~~
```

Ironically opening a bug report would result in a crash on API version lower than 33.

Introduced with 098fb150dfc64bac893c213dcaabf0b0d83fa24b