### PR TITLE
fix: Typo in selected browser preference usage

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -1199,12 +1199,10 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 				int selectedBrowser = Integer.parseInt(mPrefs.getString(SettingsActivity.SP_DISPLAY_BROWSER, "0"));
 				switch(selectedBrowser) {
 					case 0:
+					case 2:
 						openRssItemInCustomTab(currentUrl);
 						break;
 					case 1:
-						//openRssItemInInternalBrowser(currentUrl);
-						break;
-					case 2:
 						openRssItemInExternalBrowser(currentUrl);
 						break;
 				}


### PR DESCRIPTION
The values used for selected browser aren't the ones set in strings.xml.

Fixes issue #1289