### PR TITLE
downloaded podcast refactoring

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
@@ -329,21 +329,20 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
         }
 
         AlertDialog.Builder alertDialog = new AlertDialog.Builder(this)
-                .setNegativeButton("Remove", (dialogInterface, i) -> {
+                .setNegativeButton(getString(R.string.dialog_podcast_remove_confirm), (dialogInterface, i) -> {
                     boolean success = file.delete() && file.getParentFile().delete(); // remove audio file and parent folder
                     if (!success) {
-                        Toast.makeText(PodcastFragmentActivity.this, "Failed to remove media for \"" + podcastItem.title + "\"", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(PodcastFragmentActivity.this, getString(R.string.dialog_podcast_status_failed, podcastItem.title), Toast.LENGTH_SHORT).show();
                     } else {
-                        Toast.makeText(PodcastFragmentActivity.this, "Media for \"" + podcastItem.title + "\" has been removed", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(PodcastFragmentActivity.this, getString(R.string.dialog_podcast_status_success, podcastItem.title), Toast.LENGTH_SHORT).show();
                     }
-
                     callback.accept(success);
                 })
-                .setNeutralButton("Cancel", (dialogInterface, i) -> {
+                .setNeutralButton(getString(android.R.string.cancel), (dialogInterface, i) -> {
                     callback.accept(false);
                 })
-                .setTitle("Are you sure?")
-                .setMessage("Do you want to remove downloaded media for \"" + podcastItem.title + "?\"");
+                .setTitle(getString(R.string.dialog_podcast_remove_title))
+                .setMessage(getString(R.string.dialog_podcast_remove_body, podcastItem.title));
 
         alertDialog.show();
     }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
@@ -74,11 +74,7 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.V
 
         EventBus.getDefault().register(this);
 
-        if (recyclerView.getLayoutManager() instanceof LinearLayoutManager) {
-
-            final LinearLayoutManager linearLayoutManager =
-                    (LinearLayoutManager) recyclerView.getLayoutManager();
-
+        if (recyclerView.getLayoutManager() instanceof LinearLayoutManager linearLayoutManager) {
 
             recyclerView
                     .addOnScrollListener(new RecyclerView.OnScrollListener() {
@@ -92,7 +88,8 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.V
                                     .findLastVisibleItemPosition();
                             if (!loading &&
                                     adapterTotalItemCount <= (lastVisibleItem + visibleThreshold) &&
-                                    adapterTotalItemCount < totalItemCount) {
+                                    adapterTotalItemCount < totalItemCount &&
+                                    adapterTotalItemCount > 0) {
                                 loading = true;
 
                                 Log.v(TAG, "start load more task...");
@@ -100,10 +97,15 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.V
                                 recyclerView.post(() -> {
                                     // End has been reached
                                     // Do something
-                                    lazyList.add(null);
-                                    notifyItemInserted(lazyList.size() - 1);
-
-                                    AsyncTaskHelper.StartAsyncTask(new LoadMoreItemsAsyncTask());
+                                    try {
+                                        lazyList.add(null);
+                                        notifyItemInserted(lazyList.size() - 1);
+                                        AsyncTaskHelper.StartAsyncTask(new LoadMoreItemsAsyncTask());
+                                    } catch (UnsupportedOperationException ex) {
+                                        Log.e(TAG, "error while lazy loading more items");
+                                        // this can happen in case a podcast download is running and
+                                        // the user tries to open the Downloaded Podcast View
+                                    }
                                 });
                             }
                         }
@@ -378,7 +380,7 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.V
             List<RssItem> rssItems = refreshAdapterData();
 
             sw.stop();
-            Log.v(TAG, "Time needed (refreshing adapter): " + sw.toString());
+            Log.v(TAG, "Time needed (refreshing adapter): " + sw);
 
             return rssItems;
         }
@@ -407,7 +409,7 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.V
             List<RssItem> items = dbConn.getCurrentRssItemView(cachedPages++);
 
             sw.stop();
-            Log.v(TAG, "Time needed (loading more): " + sw.toString());
+            Log.v(TAG, "Time needed (loading more): " + sw);
             return items;
         }
 
@@ -440,7 +442,7 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.V
             holder.rssItems = list;
 
             sw.stop();
-            Log.v(TAG, "Reloaded CurrentRssView - time taken: " + sw.toString());
+            Log.v(TAG, "Reloaded CurrentRssView - time taken: " + sw);
             return holder;
         }
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
@@ -70,7 +70,7 @@ public class DatabaseConnectionOrm {
 
     private final static int PageSize = 25;
 
-    private Context context;
+    private final Context context;
 
     protected @Inject @Named("databaseFileName") String databasePath;
 
@@ -750,16 +750,15 @@ public class DatabaseConnectionOrm {
         return getStringSparseArrayFromSQL(buildSQL, 0, 1);
     }
 
-    public SparseArray<String> getDownloadedPodcastsCount(Context context) {
+    public int getDownloadedPodcastsCount(Context context) {
         var ids = NewsFileUtils.getDownloadedPodcastsFingerprints(context);
         var files = Arrays.stream(ids).map((f) -> "\"" + f + "\"").collect(Collectors.toList());
 
-        String buildSQL = "SELECT " + RssItemDao.Properties.FeedId.columnName + ", COUNT(1)" + // rowid as _id,
+        String buildSQL = "SELECT COUNT(1)" +
                 " FROM " + RssItemDao.TABLENAME +
-                " WHERE " + RssItemDao.Properties.Fingerprint.columnName + " in (" + String.join(",", files) + ")" +
-                " GROUP BY " + RssItemDao.Properties.FeedId.columnName;
+                " WHERE " + RssItemDao.Properties.Fingerprint.columnName + " in (" + String.join(",", files) + ")";
 
-        return getStringSparseArrayFromSQL(buildSQL, 0, 1);
+        return (int) getLongValueBySQL(buildSQL);
     }
 
     public void clearDatabaseOverSize()

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -228,7 +228,11 @@
     <string name="exit_playback">Exit Player</string>
     <string name="podcast_playback_speed_dialog_title">Playback Speed</string>
     <string name="notification_downloading_podcast_title">Downloading podcast</string>
-
+    <string name="dialog_podcast_remove_title">Are you sure?</string>
+    <string name="dialog_podcast_remove_body">Do you want to remove downloaded media for  %1$s?</string>
+    <string name="dialog_podcast_status_failed">Failed to remove media for %1$s</string>
+    <string name="dialog_podcast_status_success">Media for %1$s has been removed</string>
+    <string name="dialog_podcast_remove_confirm">Remove</string>
 
     <!-- Settings for About -->
     <string name="pref_header_about">About</string>


### PR DESCRIPTION
- Add translatable strings
- Fix bug where app crashes when the user tries to open the "Downloaded podcasts" while a download is running
- Fix bug where "Downloaded podcasts" is not showing in case "Show only unread articles" is selected in the settings.
- Show the number of items in the "Downloaded podcasts" section in the sidebar
- Remove duplicate code due to merging