### PR TITLE
hide empty/broken iframes

### DIFF
--- a/News-Android-App/src/main/assets/web.css
+++ b/News-Android-App/src/main/assets/web.css
@@ -76,6 +76,10 @@ body {
     margin-right: 1rem;
 }
 
+body iframe:not([src]) {
+    display: none;
+}
+
 img {
     /* make images fill the whole screen */
     max-width:   calc(100% + 2rem) !important;


### PR DESCRIPTION
Fix for https://github.com/nextcloud/news-android/issues/1368