### PR TITLE
Fix crash in downloaded podcasts below API 34

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -539,7 +539,7 @@ public class NewsReaderDetailFragment extends Fragment {
                 items = items.stream().filter((rss) -> {
                     var podcast = DatabaseConnectionOrm.ParsePodcastItemFromRssItem(mActivity, rss);
                     return podcast.offlineCached;
-                }).toList();
+                }).collect(Collectors.toList());
             }
 
             sw.stop();


### PR DESCRIPTION
Fixes #1381

According to https://issuetracker.google.com/issues/304335616 `java.util.stream.Stream.toList` is not supported (yet) by desugar library.

Use `java.util.stream.Collectors.toList` instead [which is supported by desugar library](https://developer.android.com/studio/write/java11-default-support-table).