### PR TITLE
Update favIconHandler's context on RssItemViewHolder bind

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/RssItemViewHolder.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/RssItemViewHolder.java
@@ -220,6 +220,7 @@ public abstract class RssItemViewHolder<T extends ViewBinding> extends RecyclerV
 
 
         ImageView imgViewFavIcon = getImageViewFavIcon();
+        favIconHandler.setContext(itemView.getContext());
         if (imgViewFavIcon != null) {
             favIconHandler.loadFavIconForFeed(favIconUrl, imgViewFavIcon, Math.round((marginFavIcon - sizeOfFavIcon) / 2f));
         }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/FavIconHandler.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/FavIconHandler.java
@@ -48,8 +48,8 @@ import de.luhmer.owncloudnewsreader.database.model.Feed;
 public class FavIconHandler {
     private static final String TAG = FavIconHandler.class.getCanonicalName();
 
-    private final RequestManager mGlide;
-    private final Context mContext;
+    private RequestManager mGlide;
+    private Context mContext;
     private final int mPlaceHolder;
 
     public FavIconHandler(Context context) {
@@ -154,5 +154,10 @@ public class FavIconHandler {
         } else {
             Log.v(TAG, "Failed to update AVG color of feed: " + feedId);
         }
+    }
+
+    public void setContext(Context context) {
+        mContext = context;
+        mGlide = Glide.with(context);
     }
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/FavIconHandler.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/FavIconHandler.java
@@ -157,6 +157,9 @@ public class FavIconHandler {
     }
 
     public void setContext(Context context) {
+        if (context == mContext) {
+            return;
+        }
         mContext = context;
         mGlide = Glide.with(context);
     }


### PR DESCRIPTION
On changing the theme the context the favIconHandler is holding seems to become invalid. You can see the resulting issue here:

https://github.com/nextcloud/news-android/assets/11160629/f2c1e822-b823-48cc-8abc-cbf7bf45877f

This was recorded on a virtual android device (pixel 4 API 33) and coud also be reproduced on my physical pixel 7a running android 14.
I'm sadly not much of an android dev, so I'm not sure if this is the best solution but it does fix the issue. What I could tell is that the request glide (which also holds a reference to this context) is making is neither successful nor fails so it just leaves the placeholder in place (I added [RequestListener](https://bumptech.github.io/glide/doc/debugging.html#requestlistener-and-custom-logs)s and neither `onLoadFailed` nor `onResourceReady` ever gets called in these cases).

I also wonder if [this issue](https://github.com/nextcloud/news-android/issues/1277) has a similar root cause, but I haven't been able to reliably reproduce it.