### PR TITLE
cleanup proguard gson rules

### DIFF
--- a/News-Android-App/proguard-rules.pro
+++ b/News-Android-App/proguard-rules.pro
@@ -46,40 +46,8 @@
 -dontwarn com.sothree.slidinguppanel.SlidingUpPanelLayout
 
 # Gson
-# Following are rules from
-# https://github.com/google/gson/blob/37ed0fcbd7930df0aad9f5068c608e4465413877/examples/android-proguard-example/proguard.cfg
-# no rules are packaged into gson (as of 2.10.1)
-##---------------Begin: proguard configuration for Gson  ----------
-# Gson uses generic type information stored in a class file when working with fields. Proguard
-# removes such information by default, so configure it to keep all of it.
--keepattributes Signature
-
-# For using GSON @Expose annotation
--keepattributes *Annotation*
-
-# Gson specific classes
--dontwarn sun.misc.**
-#-keep class com.google.gson.stream.** { *; }
-
 # Application classes that will be serialized/deserialized over Gson
 -keep class com.nextcloud.android.sso.model.** { <fields>; }
-
-# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
-# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
--keep class * extends com.google.gson.TypeAdapter
--keep class * implements com.google.gson.TypeAdapterFactory
--keep class * implements com.google.gson.JsonSerializer
--keep class * implements com.google.gson.JsonDeserializer
-
-# Prevent R8 from leaving Data object members always null
--keepclassmembers,allowobfuscation class * {
-  @com.google.gson.annotations.SerializedName <fields>;
-}
-
-# Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
--keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
--keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
-
 ##---------------End: proguard configuration for Gson  ----------
 
 # Other Libraries

--- a/News-Android-App/proguard-rules.pro
+++ b/News-Android-App/proguard-rules.pro
@@ -45,10 +45,6 @@
 # https://github.com/umano/AndroidSlidingUpPanel/issues/921
 -dontwarn com.sothree.slidinguppanel.SlidingUpPanelLayout
 
-# Gson
-# Application classes that will be serialized/deserialized over Gson
--keep class com.nextcloud.android.sso.model.** { <fields>; }
-##---------------End: proguard configuration for Gson  ----------
 
 # Other Libraries
 -dontwarn org.apache.velocity.**


### PR DESCRIPTION
Follow up from: https://github.com/nextcloud/news-android/pull/1435 - sounds like we don't need the GSON rules anymore. I've removed them and tested the debug build without the GSON rules and it seemed to work just fine (we don't use `@SerializedName` because we do the deserialization mostly manually)

> Added default ProGuard / R8 rules ([@​Marcono1234](https://github.com/Marcono1234), [#2397](https://redirect.github.com/google/gson/issues/2397), [#2420](https://redirect.github.com/google/gson/issues/2420); [@​sgjesse](https://github.com/sgjesse), [#2448](https://redirect.github.com/google/gson/issues/2448); [@​sfreilich](https://github.com/sfreilich))
If you are using ProGuard or R8 (for example for Android projects) you might not need any special Gson configuration anymore if your classes have a no-args constructor and use @SerializedName for their fields.