### PR TITLE
Fix inaccurate scroll bar due to lazy loading #1232

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LazyLoadingLinearLayoutManager.kt
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LazyLoadingLinearLayoutManager.kt
@@ -1,0 +1,23 @@
+package de.luhmer.owncloudnewsreader
+
+import android.content.Context
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.roundToInt
+
+class LazyLoadingLinearLayoutManager(
+	context: Context?,
+	@RecyclerView.Orientation orientation: Int,
+	reverseLayout: Boolean
+) : LinearLayoutManager(context, orientation, reverseLayout) {
+
+	var totalItemCount: Int = 0
+
+	override fun computeVerticalScrollRange(state: RecyclerView.State): Int {
+		if (state.itemCount == 0) {
+			return 0
+		}
+
+		return (super.computeVerticalScrollRange(state) / state.itemCount.toFloat() * totalItemCount).roundToInt()
+	}
+}

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -326,7 +326,7 @@ public class NewsReaderDetailFragment extends Fragment {
         binding = FragmentNewsreaderDetailBinding.inflate(inflater, container, false);
 
         binding.list.setHasFixedSize(true);
-        binding.list.setLayoutManager(new LinearLayoutManager(mActivity, RecyclerView.VERTICAL, false));
+        binding.list.setLayoutManager(new LazyLoadingLinearLayoutManager(mActivity, RecyclerView.VERTICAL, false));
         binding.list.setItemAnimator(new DefaultItemAnimator());
 
         ItemTouchHelper itemTouchHelper = new ItemTouchHelper(new NewsReaderItemTouchHelperCallback());


### PR DESCRIPTION
This should adjust the scrollbar to take not-yet-loaded items into account by scaling up the vertical scroll range accordingly.

I've tested this with different item layouts and it seems pretty robust - but it might break in future when lazy loaded items are prepended instead of appended to the list.