### PR TITLE
fix wrong layouts on Android 15 due to default edge-to-edge feature

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -149,8 +149,9 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:1.4.0"
     implementation "androidx.browser:browser:1.8.0"
     implementation "androidx.cardview:cardview:1.0.0"
-    implementation 'com.google.code.gson:gson:2.13.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+    implementation 'com.google.code.gson:gson:2.13.0'
 
     implementation "com.github.bumptech.glide:glide:${GLIDE_VERSION}"
     ksp "com.github.bumptech.glide:ksp:${GLIDE_VERSION}"

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
@@ -40,6 +40,8 @@ import android.widget.ExpandableListView.OnChildClickListener;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.material.navigation.NavigationView;
@@ -168,7 +170,6 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 
         bindNavigationMenu(binding.getRoot(), inflater);
 
-        /*
         // move header of sidebar down according to insets
         ViewCompat.setOnApplyWindowInsetsListener(binding.headerView, (View v, WindowInsetsCompat insets) -> {
             var systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
@@ -182,7 +183,6 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
             v.setPadding(0, 0, 0, systemBars.bottom);
             return insets;
         });
-        */
 
 		return binding.getRoot();
 	}

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
@@ -168,6 +168,22 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 
         bindNavigationMenu(binding.getRoot(), inflater);
 
+        /*
+        // move header of sidebar down according to insets
+        ViewCompat.setOnApplyWindowInsetsListener(binding.headerView, (View v, WindowInsetsCompat insets) -> {
+            var systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(0, systemBars.top, 0, 0);
+            return insets;
+        });
+
+        // make sure that the end of the sidebar doesn't go behind the navigation bar
+        ViewCompat.setOnApplyWindowInsetsListener(binding.expandableListView, (View v, WindowInsetsCompat insets) -> {
+            var systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(0, 0, 0, systemBars.bottom);
+            return insets;
+        });
+        */
+
 		return binding.getRoot();
 	}
 

--- a/News-Android-App/src/main/res/layout-sw600dp-land/activity_newsreader.xml
+++ b/News-Android-App/src/main/res/layout-sw600dp-land/activity_newsreader.xml
@@ -1,20 +1,23 @@
-<de.luhmer.owncloudnewsreader.view.PodcastSlidingUpPanelLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
     xmlns:sothree="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/sliding_layout"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:gravity="bottom"
-    sothree:umanoPanelHeight="68dp"
-    sothree:umanoParallaxOffset="100dp"
-    android:fitsSystemWindows="true"
-    sothree:umanoShadowHeight="4dp"> <!-- sothree:dragView="@+id/name" -->
+    android:layout_height="match_parent">
+
+    <de.luhmer.owncloudnewsreader.view.PodcastSlidingUpPanelLayout
+        android:id="@+id/sliding_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="bottom"
+        sothree:umanoPanelHeight="68dp"
+        sothree:umanoParallaxOffset="100dp"
+        sothree:umanoShadowHeight="4dp"> <!-- sothree:dragView="@+id/name" -->
 
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:id="@+id/coordinator_layout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -44,9 +47,10 @@
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-    <FrameLayout
-        android:id="@+id/podcast_frame"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        <FrameLayout
+            android:id="@+id/podcast_frame"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
 
-</de.luhmer.owncloudnewsreader.view.PodcastSlidingUpPanelLayout>
+    </de.luhmer.owncloudnewsreader.view.PodcastSlidingUpPanelLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/News-Android-App/src/main/res/layout-sw600dp-land/activity_newsreader.xml
+++ b/News-Android-App/src/main/res/layout-sw600dp-land/activity_newsreader.xml
@@ -8,6 +8,7 @@
     android:gravity="bottom"
     sothree:umanoPanelHeight="68dp"
     sothree:umanoParallaxOffset="100dp"
+    android:fitsSystemWindows="true"
     sothree:umanoShadowHeight="4dp"> <!-- sothree:dragView="@+id/name" -->
 
         <androidx.coordinatorlayout.widget.CoordinatorLayout

--- a/News-Android-App/src/main/res/layout/activity_new_feed.xml
+++ b/News-Android-App/src/main/res/layout/activity_new_feed.xml
@@ -2,7 +2,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent"
-    android:layout_width="match_parent">
+    android:layout_width="match_parent"
+    android:fitsSystemWindows="true">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/News-Android-App/src/main/res/layout/activity_news_detail.xml
+++ b/News-Android-App/src/main/res/layout/activity_news_detail.xml
@@ -1,7 +1,8 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
-    android:layout_width="match_parent">
+    android:layout_width="match_parent"
+    android:fitsSystemWindows="true">
 
     <!-- SlidingUpPanelLayout doesn't work with layout_behavior, use marginTop -->
     <de.luhmer.owncloudnewsreader.view.PodcastSlidingUpPanelLayout

--- a/News-Android-App/src/main/res/layout/activity_newsreader.xml
+++ b/News-Android-App/src/main/res/layout/activity_newsreader.xml
@@ -8,6 +8,7 @@
     android:gravity="bottom"
     sothree:umanoPanelHeight="68dp"
     sothree:umanoParallaxOffset="100dp"
+    android:fitsSystemWindows="true"
     sothree:umanoShadowHeight="4dp"> <!-- sothree:dragView="@+id/name" -->
 
     <androidx.drawerlayout.widget.DrawerLayout
@@ -32,7 +33,6 @@
             <include
                 android:id="@+id/toolbar_layout"
                 layout="@layout/toolbar_layout" />
-
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/News-Android-App/src/main/res/layout/activity_newsreader.xml
+++ b/News-Android-App/src/main/res/layout/activity_newsreader.xml
@@ -1,15 +1,17 @@
-<de.luhmer.owncloudnewsreader.view.PodcastSlidingUpPanelLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
     xmlns:sothree="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="match_parent">
+
+    <de.luhmer.owncloudnewsreader.view.PodcastSlidingUpPanelLayout
     android:id="@+id/sliding_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="bottom"
     sothree:umanoPanelHeight="68dp"
     sothree:umanoParallaxOffset="100dp"
-    android:fitsSystemWindows="true"
-    sothree:umanoShadowHeight="4dp"> <!-- sothree:dragView="@+id/name" -->
+        android:gravity="bottom"
+        sothree:umanoShadowHeight="4dp"> <!-- sothree:dragView="@+id/name" -->
 
     <androidx.drawerlayout.widget.DrawerLayout
         android:id="@+id/drawer_layout"
@@ -19,7 +21,8 @@
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:id="@+id/coordinator_layout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true">
 
             <fragment
                 class="de.luhmer.owncloudnewsreader.NewsReaderDetailFragment"
@@ -50,3 +53,4 @@
         android:layout_height="match_parent" />
 
 </de.luhmer.owncloudnewsreader.view.PodcastSlidingUpPanelLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/News-Android-App/src/main/res/layout/activity_pip_video_playback.xml
+++ b/News-Android-App/src/main/res/layout/activity_pip_video_playback.xml
@@ -4,8 +4,6 @@
     android:id="@+id/layout_activity_pip"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".PiPVideoPlaybackActivity">
-
-
-
 </RelativeLayout>

--- a/News-Android-App/src/main/res/layout/activity_settings.xml
+++ b/News-Android-App/src/main/res/layout/activity_settings.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:orientation="vertical">
 
     <include
         android:id="@+id/toolbar_layout"

--- a/News-Android-App/src/main/res/layout/fragment_newsreader_detail.xml
+++ b/News-Android-App/src/main/res/layout/fragment_newsreader_detail.xml
@@ -17,6 +17,7 @@
             android:layout_height="match_parent"
             android:scrollbars="vertical"
             tools:listitem="@layout/subscription_detail_list_item_thumbnail"/>
+        <!-- android:clipToPadding="false" -->
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 

--- a/News-Android-App/src/main/res/layout/fragment_newsreader_list.xml
+++ b/News-Android-App/src/main/res/layout/fragment_newsreader_list.xml
@@ -4,62 +4,69 @@
     android:layout_height="match_parent"
     android:background="?attr/colorSurface">
 
-    <!-- TODO: make header scroll up with listview -->
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <!-- Wrap in Frame-Layout so that we can add Padding through the Edge-to-Edge callbacks -->
+    <FrameLayout
         android:id="@+id/header_view"
         android:layout_width="match_parent"
-        android:layout_height="100dp"
-        android:background="@color/nextcloudBlue"
-        android:clickable="true"
-        android:focusable="true"
-        android:padding="10dp">
+        android:layout_height="wrap_content"
+        android:background="@color/nextcloudBlue">
 
-        <TextView
-            android:id="@+id/appName"
-            android:layout_width="wrap_content"
+        <!-- TODO: make header scroll up with listview -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/spacer_2x"
-            android:layout_toEndOf="@+id/header_logo"
-            android:ellipsize="end"
-            android:fontFamily="sans-serif-light"
-            android:gravity="center_vertical"
-            android:singleLine="true"
-            android:text="@string/app_name"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:textColor="@android:color/white"
-            android:textSize="24sp"
-            app:layout_constraintBottom_toBottomOf="@id/header_logo"
-            app:layout_constraintStart_toEndOf="@id/header_logo"
-            app:layout_constraintTop_toTopOf="@id/header_logo" />
+            android:clickable="true"
+            android:focusable="true"
+            android:paddingHorizontal="10dp"
+            android:paddingVertical="16dp">
 
-        <ImageView
-            android:id="@+id/header_logo"
-            android:layout_width="56dp"
-            android:layout_height="56dp"
-            android:layout_marginStart="@dimen/spacer_1x"
-            android:contentDescription="@string/content_desc_tap_to_refresh"
-            android:scaleX="1.7"
-            android:scaleY="1.7"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_launcher_foreground" />
+            <TextView
+                android:id="@+id/appName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/spacer_2x"
+                android:layout_toEndOf="@+id/header_logo"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif-light"
+                android:gravity="center_vertical"
+                android:singleLine="true"
+                android:text="@string/app_name"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="@android:color/white"
+                android:textSize="24sp"
+                app:layout_constraintBottom_toBottomOf="@id/header_logo"
+                app:layout_constraintStart_toEndOf="@id/header_logo"
+                app:layout_constraintTop_toTopOf="@id/header_logo" />
 
-        <ProgressBar
-            android:id="@+id/header_logo_progress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_gravity="center"
-            android:indeterminate="true"
-            android:indeterminateTint="@android:color/white"
-            android:indeterminateTintMode="src_in"
-            app:layout_constraintBottom_toBottomOf="@id/header_logo"
-            app:layout_constraintEnd_toEndOf="@id/header_logo"
-            app:layout_constraintStart_toStartOf="@id/header_logo"
-            app:layout_constraintTop_toTopOf="@id/header_logo" />
+            <ImageView
+                android:id="@+id/header_logo"
+                android:layout_width="56dp"
+                android:layout_height="56dp"
+                android:layout_marginStart="@dimen/spacer_1x"
+                android:contentDescription="@string/content_desc_tap_to_refresh"
+                android:scaleX="1.7"
+                android:scaleY="1.7"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_launcher_foreground" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <ProgressBar
+                android:id="@+id/header_logo_progress"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="38dp"
+                android:layout_height="38dp"
+                android:layout_gravity="center"
+                android:indeterminate="true"
+                android:indeterminateTint="@android:color/white"
+                android:indeterminateTintMode="src_in"
+                app:layout_constraintBottom_toBottomOf="@id/header_logo"
+                app:layout_constraintEnd_toEndOf="@id/header_logo"
+                app:layout_constraintStart_toStartOf="@id/header_logo"
+                app:layout_constraintTop_toTopOf="@id/header_logo" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </FrameLayout>
 
     <de.luhmer.owncloudnewsreader.ListView.BlockingExpandableListView
         android:id="@+id/expandableListView"

--- a/News-Android-App/src/main/res/layout/toolbar_layout.xml
+++ b/News-Android-App/src/main/res/layout/toolbar_layout.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.appbar.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:fitsSystemWindows="true">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"


### PR DESCRIPTION
Since Android 15 (Target SDK 35) Edge-To-Edge is enabled by default.. which breaks the app quite a bit since the AppBars etc.. are hidden behind the status bar because we don't use Compose yet. 

--> https://developer.android.com/develop/ui/views/layout/edge-to-edge

Since it was quite tricky to find a solution for the Podcast Overlay etc.. Positioning them correctly by respecting the insets seems to be somewhat difficult. Therefore, for now I'm just using the `android:fitsSystemWindows="true"` to restore the previous functionality.