### PR TITLE
remove incorrect FormUrlEncoded annotation

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/nextcloud/NewsAPI.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/nextcloud/NewsAPI.java
@@ -17,7 +17,6 @@ import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
 import retrofit2.http.Field;
-import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.PUT;
@@ -54,7 +53,6 @@ public interface NewsAPI {
     @POST("folders")
     Observable<List<Folder>> createFolderObservable(@Body Map<String, Object> folderMap);
 
-    @FormUrlEncoded
     @POST("feeds")
     Call<List<Feed>> createFeed(@Field("url") String url, @Field("folderId") Long parentFolderID);
 


### PR DESCRIPTION
No idea why I added the `@FormUrlEncoded` annotation in the first place. The specs (https://nextcloud.github.io/news/api/api-v1-3/#get-all-feeds) are not expecting it and it causes issues with custom server implementation as mentioned in #1510.

Fix for https://github.com/nextcloud/news-android/issues/1510