### PR TITLE
downgrade to sdk 35

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -11,7 +11,7 @@ android {
     testOptions.unitTests.includeAndroidResources = true
 
     defaultConfig {
-        compileSdk Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+        compileSdk = Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
         minSdkVersion Integer.parseInt(project.ANDROID_BUILD_MIN_SDK_VERSION)
         targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,8 @@
 # org.gradle.parallel=true
 
 ANDROID_BUILD_MIN_SDK_VERSION=21
-ANDROID_BUILD_TARGET_SDK_VERSION=36
-ANDROID_BUILD_SDK_VERSION=36
+ANDROID_BUILD_TARGET_SDK_VERSION=35
+ANDROID_BUILD_SDK_VERSION=35
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.dependency.verification.console=verbose

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 ANDROID_BUILD_MIN_SDK_VERSION=21
 ANDROID_BUILD_TARGET_SDK_VERSION=36
-ANDROID_BUILD_SDK_VERSION=35
+ANDROID_BUILD_SDK_VERSION=36
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.dependency.verification.console=verbose


### PR DESCRIPTION
better to wait for official migration assistant for v36 - even though some libs seem to already require it https://github.com/nextcloud/news-android/pull/1571