### PR TITLE
Handle URL encoding when reading mediaThumbnail from body

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/nextcloud/InsertRssItemIntoDatabase.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/nextcloud/InsertRssItemIntoDatabase.java
@@ -21,6 +21,7 @@
 
 package de.luhmer.owncloudnewsreader.reader.nextcloud;
 
+import android.text.Html;
 import android.util.Log;
 
 import com.google.gson.JsonObject;
@@ -132,7 +133,7 @@ class InsertRssItemIntoDatabase {
         if(mediaThumbnail.isEmpty()) {
             List<String> images = ImageHandler.getImageLinksFromText(url, content);
             if (!images.isEmpty()) {
-                mediaThumbnail = images.get(0);
+                mediaThumbnail = Html.fromHtml(images.get(0)).toString();
                 // Log.d(TAG, "extracted mediaThumbnail from body" + mediaThumbnail);
             } else {
                 Log.d(TAG, "extraction of mediaThumbnail not possible - no images detected");


### PR DESCRIPTION
Some feeds use images with URL parameters, e.g. to pick the correct size. One of these is the [Tagesschau RSS feed](https://www.tagesschau.de/infoservices/alle-meldungen-100~rss2.xml). It uses images like:
`https://images.tagesschau.de/image/af678f53-3b9f-41c3-9478-58ffa7ca4d29/AAABmpISkSU/AAABmgWmh8Q/16x9-big/merz-1102.jpg?width=1920`
When viewing the article preview, the image is shown correctly. But the thumbnails in the list view only show the placeholder and following error is logged:
```
2025-11-17 17:06:20.848 20397-20397 Glide                   de.luhmer.owncloudnewsreader.dev     W  Load failed for [https://images.tagesschau.de/image/af678f53-3b9f-41c3-9478-58ffa7ca4d29/AAABmpISkSU/AAABmgWmh8Q/16x9-big/merz-1102.jpg?width&#61;1920] with dimensions [231x231]
                                                                                                    class com.bumptech.glide.load.engine.GlideException: Failed to load resource
                                                                                                    There was 1 root cause:
                                                                                                    com.bumptech.glide.load.HttpException(Failed to connect or obtain data, status code: 400)
                                                                                                     call GlideException#logRootCauses(String) for more detail
```
which means the URL parameters are not correctly decoded, and glide tries to retrieve `https://images.tagesschau.de/image/af678f53-3b9f-41c3-9478-58ffa7ca4d29/AAABmpISkSU/AAABmgWmh8Q/16x9-big/merz-1102.jpg?width&#61;1920` instead.

As the article preview works as expected on both Nextcloud News and in the app I figure this is probably not an issue with the RSS feed itself, but with how the image is retrieved from the body. My best guess was to add HTML-decoding as part of that logic and that definitely fixes the issue for me without breaking any other images.

I'm not really familiar enough with the codebase to know whether this is the best place to do this and I can't fully discount that this is an upstream issue with the Nextcloud News API/this particular feed, so please let me know if this makes sense at all.