### PR TITLE
Fix text to speech for long articles, add pause/resume and voice settings shortcut

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
@@ -297,41 +297,44 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "onStartCommand() called with: intent = [" + intent + "], flags = [" + flags + "], startId = [" + startId + "]");
-        MediaButtonReceiver.handleIntent(mSession, intent);
-
-        if (intent != null) {
-            if (mPlaybackService != null) {
-                mPlaybackService.destroy();
-                mPlaybackService = null;
-            }
-
-            stopProgressUpdates();
-
-            if(intent.hasExtra(MEDIA_ITEM)) {
-                MediaItem mediaItem = (MediaItem) intent.getSerializableExtra(MEDIA_ITEM);
-
-                if (mediaItem instanceof PodcastItem) {
-                    //if (((PodcastItem) mediaItem).isYoutubeVideo()) {
-                    //    mPlaybackService = new YoutubePlaybackService(this, podcastStatusListener, mediaItem);
-                    //} else {
-                        mPlaybackService = new MediaPlayerPlaybackService(this, podcastStatusListener, mediaItem);
-                    //}
-                } else if (mediaItem instanceof TTSItem) {
-                    mPlaybackService = new TTSPlaybackService(this, podcastStatusListener, mediaItem);
-                }
-
-                updateMetadata(mediaItem);
-
-                // Update notification after setting metadata (notification uses metadata information)
-                podcastNotification.createPodcastNotification();
-
-                mPlaybackService.playbackSpeedChanged(currentPlaybackSpeed);
-
-                startProgressUpdates();
-
-                requestAudioFocus();
-            }
+        if (intent == null) {
+            return super.onStartCommand(null, flags, startId);
         }
+
+        if (!intent.hasExtra(MEDIA_ITEM)) {
+            MediaButtonReceiver.handleIntent(mSession, intent);
+            return super.onStartCommand(intent, flags, startId);
+        }
+
+        if (mPlaybackService != null) {
+            mPlaybackService.destroy();
+            mPlaybackService = null;
+        }
+
+        stopProgressUpdates();
+
+        MediaItem mediaItem = (MediaItem) intent.getSerializableExtra(MEDIA_ITEM);
+
+        if (mediaItem instanceof PodcastItem) {
+            //if (((PodcastItem) mediaItem).isYoutubeVideo()) {
+            //    mPlaybackService = new YoutubePlaybackService(this, podcastStatusListener, mediaItem);
+            //} else {
+                mPlaybackService = new MediaPlayerPlaybackService(this, podcastStatusListener, mediaItem);
+            //}
+        } else if (mediaItem instanceof TTSItem) {
+            mPlaybackService = new TTSPlaybackService(this, podcastStatusListener, mediaItem);
+        }
+
+        updateMetadata(mediaItem);
+
+        // Update notification after setting metadata (notification uses metadata information)
+        podcastNotification.createPodcastNotification();
+
+        mPlaybackService.playbackSpeedChanged(currentPlaybackSpeed);
+
+        startProgressUpdates();
+
+        requestAudioFocus();
 
         return super.onStartCommand(intent, flags, startId);
     }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/podcast/TTSPlaybackService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/podcast/TTSPlaybackService.java
@@ -6,7 +6,8 @@ import android.speech.tts.UtteranceProgressListener;
 import android.support.v4.media.session.PlaybackStateCompat;
 import android.util.Log;
 
-import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 
 import de.luhmer.owncloudnewsreader.model.MediaItem;
 import de.luhmer.owncloudnewsreader.model.TTSItem;
@@ -16,7 +17,22 @@ import de.luhmer.owncloudnewsreader.model.TTSItem;
  */
 
 public class TTSPlaybackService extends PlaybackService implements TextToSpeech.OnInitListener {
+
+    private static final String TAG = "TTSPlaybackService";
+
+    // A single speak() call drops text longer than getMaxSpeechInputLength(), so longer
+    // articles have to be split and queued. The size is kept small on purpose: it stays clear
+    // of multi byte scripts (e.g. Greek) and it is also the granularity we can resume at after
+    // a pause, since TextToSpeech itself cannot pause and continue. The splitter cuts at
+    // sentence ends, so the pieces still sound natural.
+    private static final int CHUNK_SIZE = Math.min(TextToSpeech.getMaxSpeechInputLength(), 200);
+
+    private static final String UTTERANCE_PREFIX = "tts_";
+
     private TextToSpeech ttsController;
+    private List<String> chunks;
+    private int currentChunk;
+    private String lastUtteranceId;
 
     public TTSPlaybackService(Context context, PodcastStatusListener podcastStatusListener, MediaItem mediaItem) {
         super(podcastStatusListener, mediaItem);
@@ -28,12 +44,24 @@ public class TTSPlaybackService extends PlaybackService implements TextToSpeech.
             if(ttsController != null) {
                 ttsController.setOnUtteranceProgressListener(new UtteranceProgressListener() {
                     @Override
-                    public void onDone(String utteranceId) {
-                        podcastCompleted();
+                    public void onStart(String utteranceId) {
+                        // Remember the piece we are on so play() can resume here after a pause
+                        currentChunk = indexOf(utteranceId);
                     }
 
-                    @Override public void onStart(String utteranceId) {}
-                    @Override public void onError(String utteranceId) {}
+                    @Override
+                    public void onDone(String utteranceId) {
+                        // Only finish once the last chunk was spoken
+                        if (utteranceId != null && utteranceId.equals(lastUtteranceId)) {
+                            podcastCompleted();
+                        }
+                    }
+
+                    @Override
+                    public void onError(String utteranceId) {
+                        Log.e(TAG, "TTS error while speaking " + utteranceId);
+                        setStatus(PlaybackStateCompat.STATE_ERROR);
+                    }
                 });
             } else {
                 onInit(TextToSpeech.SUCCESS);
@@ -46,18 +74,25 @@ public class TTSPlaybackService extends PlaybackService implements TextToSpeech.
     @Override
     public void destroy() {
         pause();
-        ttsController.shutdown();
-        ttsController = null;
+        if (ttsController != null) {
+            ttsController.shutdown();
+            ttsController = null;
+        }
     }
 
     @Override
     public void play() {
-        onInit(TextToSpeech.SUCCESS);//restart last tts
+        // Resume at the piece that was interrupted. Start fresh if nothing was prepared yet.
+        if (ttsController != null && chunks != null && !chunks.isEmpty()) {
+            speakFrom(currentChunk);
+        } else {
+            onInit(TextToSpeech.SUCCESS);
+        }
     }
 
     @Override
     public void pause() {
-        if (ttsController.isSpeaking()) {
+        if (ttsController != null && ttsController.isSpeaking()) {
             ttsController.stop();
             setStatus(PlaybackStateCompat.STATE_PAUSED);
         }
@@ -71,24 +106,49 @@ public class TTSPlaybackService extends PlaybackService implements TextToSpeech.
     @Override
     public void onInit(int status) {
         if (status == TextToSpeech.SUCCESS) {
-            /*
-            int result = ttsController.setLanguage(Locale.US);
+            // Use the device language so the engine picks a fitting voice. The user can change
+            // engine and voice through the system TTS settings shortcut in the app settings.
+            ttsController.setLanguage(Locale.getDefault());
 
-            if (result == TextToSpeech.LANG_MISSING_DATA
-                    || result == TextToSpeech.LANG_NOT_SUPPORTED) {
-                Log.e("TTS", "This Language is not supported");
-            } else {
-                ttsController.speak(text, TextToSpeech.QUEUE_FLUSH, null);
-            }*/
+            String text = ((TTSItem) getMediaItem()).text;
+            chunks = TtsTextSplitter.split(text, CHUNK_SIZE);
 
-            HashMap<String,String> ttsParams = new HashMap<>();
-            ttsParams.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID,"dummyId");
-            ttsController.speak(((TTSItem)getMediaItem()).text, TextToSpeech.QUEUE_FLUSH, ttsParams);
-            setStatus(PlaybackStateCompat.STATE_PLAYING);
+            if (chunks.isEmpty()) {
+                setStatus(PlaybackStateCompat.STATE_ERROR);
+                return;
+            }
+
+            speakFrom(0);
         } else {
             Log.e("TTS", "Initialization Failed!");
             ttsController = null;
         }
+    }
+
+    private void speakFrom(int startIndex) {
+        lastUtteranceId = UTTERANCE_PREFIX + (chunks.size() - 1);
+
+        for (int i = startIndex; i < chunks.size(); i++) {
+            int queueMode = (i == startIndex) ? TextToSpeech.QUEUE_FLUSH : TextToSpeech.QUEUE_ADD;
+            int result = ttsController.speak(chunks.get(i), queueMode, null, UTTERANCE_PREFIX + i);
+            if (result == TextToSpeech.ERROR) {
+                Log.e(TAG, "Failed to queue chunk " + i);
+                setStatus(PlaybackStateCompat.STATE_ERROR);
+                return;
+            }
+        }
+        setStatus(PlaybackStateCompat.STATE_PLAYING);
+    }
+
+    private int indexOf(String utteranceId) {
+        if (utteranceId != null && utteranceId.startsWith(UTTERANCE_PREFIX)) {
+            try {
+                return Integer.parseInt(utteranceId.substring(UTTERANCE_PREFIX.length()));
+            } catch (NumberFormatException e) {
+                Log.e(TAG, "Unexpected utterance id " + utteranceId);
+            }
+        }
+        return 0;
     }
 
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/podcast/TtsTextSplitter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/podcast/TtsTextSplitter.java
@@ -1,0 +1,78 @@
+package de.luhmer.owncloudnewsreader.services.podcast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Splits article text into pieces small enough for a single TextToSpeech.speak() call.
+ * Anything longer than getMaxSpeechInputLength() gets rejected by the engine, so longer
+ * articles need to be cut up and queued (see issue #839). We try to cut at sentence ends,
+ * fall back to word boundaries and only cut hard when there is no other option.
+ */
+public final class TtsTextSplitter {
+
+    private TtsTextSplitter() { }
+
+    public static List<String> split(String text, int maxLen) {
+        if (maxLen <= 0) {
+            throw new IllegalArgumentException("maxLen must be > 0, was " + maxLen);
+        }
+
+        List<String> chunks = new ArrayList<>();
+        if (text == null) {
+            return chunks;
+        }
+
+        String remaining = text.trim();
+        while (!remaining.isEmpty()) {
+            if (remaining.length() <= maxLen) {
+                chunks.add(remaining);
+                break;
+            }
+
+            int splitAt = findSplitIndex(remaining, maxLen);
+            String chunk = remaining.substring(0, splitAt).trim();
+            if (!chunk.isEmpty()) {
+                chunks.add(chunk);
+            }
+            remaining = remaining.substring(splitAt).trim();
+        }
+        return chunks;
+    }
+
+    private static int findSplitIndex(String text, int maxLen) {
+        int window = Math.min(maxLen, text.length());
+
+        int sentenceEnd = lastSentenceBoundary(text, window);
+        if (sentenceEnd > 0) {
+            return sentenceEnd;
+        }
+
+        int lastSpace = lastWhitespace(text, window);
+        if (lastSpace > 0) {
+            return lastSpace;
+        }
+
+        return maxLen;
+    }
+
+    private static int lastSentenceBoundary(String text, int window) {
+        for (int i = window - 1; i > 0; i--) {
+            char c = text.charAt(i);
+            if ((c == '.' || c == '!' || c == '?' || c == '\n')
+                    && (i + 1 >= text.length() || Character.isWhitespace(text.charAt(i + 1)))) {
+                return i + 1;
+            }
+        }
+        return -1;
+    }
+
+    private static int lastWhitespace(String text, int window) {
+        for (int i = window - 1; i > 0; i--) {
+            if (Character.isWhitespace(text.charAt(i))) {
+                return i + 1;
+            }
+        }
+        return -1;
+    }
+}

--- a/News-Android-App/src/main/res/values-de/strings.xml
+++ b/News-Android-App/src/main/res/values-de/strings.xml
@@ -160,6 +160,9 @@
 
     <string name="pref_title_general_search_in">Suche in</string>
 
+    <string name="pref_title_tts_settings">Sprachausgabe und Stimme</string>
+    <string name="pref_summary_tts_settings">Öffnet die Systemeinstellungen, um Modul und Stimme für das Vorlesen von Artikeln zu wählen</string>
+
     <string name="pref_general_search_in_title">Titel</string>
     <string name="pref_general_search_in_body">Artikel</string>
     <string name="pref_general_search_in_both">Beide</string>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -191,6 +191,9 @@
 
     <string name="pref_title_general_search_in">Search In</string>
 
+    <string name="pref_title_tts_settings">Speech engine and voice</string>
+    <string name="pref_summary_tts_settings">Open the system settings to choose the engine and voice used for reading articles aloud</string>
+
     <string name="pref_general_search_in_title">Title</string>
     <string name="pref_general_search_in_body">Body</string>
     <string name="pref_general_search_in_both">Both</string>

--- a/News-Android-App/src/main/res/xml/pref_general.xml
+++ b/News-Android-App/src/main/res/xml/pref_general.xml
@@ -134,6 +134,15 @@
             android:title="@string/pref_title_general_search_in"
             app:iconSpaceReserved="false"/>
 
+        <!-- Opens the system Text-to-Speech settings so the user can pick a better engine/voice. -->
+        <Preference
+            android:key="pref_tts_settings"
+            android:title="@string/pref_title_tts_settings"
+            android:summary="@string/pref_summary_tts_settings"
+            app:iconSpaceReserved="false">
+            <intent android:action="com.android.settings.TTS_SETTINGS" />
+        </Preference>
+
         <!--
              NOTE: Hide buttons to simplify the UI. Users can touch outside the dialog to
              dismiss it.

--- a/News-Android-App/src/test/java/de/luhmer/owncloudnewsreader/junit_tests/TtsTextSplitterTest.java
+++ b/News-Android-App/src/test/java/de/luhmer/owncloudnewsreader/junit_tests/TtsTextSplitterTest.java
@@ -1,0 +1,86 @@
+package de.luhmer.owncloudnewsreader.junit_tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import de.luhmer.owncloudnewsreader.services.podcast.TtsTextSplitter;
+
+public class TtsTextSplitterTest {
+
+    @Test
+    public void testNullReturnsEmpty() {
+        assertTrue(TtsTextSplitter.split(null, 100).isEmpty());
+    }
+
+    @Test
+    public void testEmptyReturnsEmpty() {
+        assertTrue(TtsTextSplitter.split("   ", 100).isEmpty());
+    }
+
+    @Test
+    public void testShortTextStaysSingleChunk() {
+        List<String> chunks = TtsTextSplitter.split("Hello world.", 100);
+        assertEquals(1, chunks.size());
+        assertEquals("Hello world.", chunks.get(0));
+    }
+
+    @Test
+    public void testLongTextIsSplitAndEachChunkWithinLimit() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 500; i++) {
+            sb.append("This is sentence number ").append(i).append(". ");
+        }
+        int maxLen = 200;
+        List<String> chunks = TtsTextSplitter.split(sb.toString(), maxLen);
+        assertTrue("expected multiple chunks", chunks.size() > 1);
+        for (String chunk : chunks) {
+            assertTrue("chunk exceeds maxLen: " + chunk.length(), chunk.length() <= maxLen);
+        }
+    }
+
+    @Test
+    public void testSplitsAtSentenceBoundary() {
+        // Two sentences, limit forces a split; first chunk should end at the sentence end.
+        String text = "First sentence is here. Second sentence is here too.";
+        List<String> chunks = TtsTextSplitter.split(text, 30);
+        assertEquals("First sentence is here.", chunks.get(0));
+    }
+
+    @Test
+    public void testFallsBackToWhitespaceWhenNoSentenceBoundary() {
+        String text = "alpha beta gamma delta epsilon zeta eta theta";
+        int maxLen = 20;
+        List<String> chunks = TtsTextSplitter.split(text, maxLen);
+        for (String chunk : chunks) {
+            assertTrue(chunk.length() <= maxLen);
+            assertTrue("word was cut in half: '" + chunk + "'",
+                    !chunk.startsWith(" ") && !chunk.endsWith(" "));
+        }
+        // No data lost: re-joining the words yields the original sequence.
+        assertEquals(text, String.join(" ", chunks));
+    }
+
+    @Test
+    public void testHardCutForSingleVeryLongWord() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 50; i++) {
+            sb.append('x');
+        }
+        int maxLen = 10;
+        List<String> chunks = TtsTextSplitter.split(sb.toString(), maxLen);
+        for (String chunk : chunks) {
+            assertTrue(chunk.length() <= maxLen);
+        }
+        // No characters lost.
+        assertEquals(50, String.join("", chunks).length());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidMaxLenThrows() {
+        TtsTextSplitter.split("text", 0);
+    }
+}


### PR DESCRIPTION
## What

The read aloud (text to speech) feature had a couple of rough edges, this PR takes care of them:

- **Long articles stayed silent.** `TextToSpeech.speak()` rejects any text longer than `getMaxSpeechInputLength()` (4000 chars), so longer articles produced no sound and the player notification got stuck and could not be dismissed. The article text is now split into small chunks at sentence boundaries and queued one after another, so the length no longer matters. This addresses #839.
- **Pause was effectively stop.** Pressing pause and then play used to restart the whole article. The service now remembers the chunk it is currently speaking and resumes there.
- To make that work from the notification / lockscreen too, the playback service is no longer destroyed on every intent. `onStartCommand()` only rebuilds it when the intent really carries a new media item, otherwise the media button is just forwarded. The same code path is used for podcasts, so pause/resume there should benefit as well (I only tested the TTS case directly).
- **Voice quality.** Added a shortcut in the settings that opens the system text to speech settings, so the engine and voice can be picked (or a better engine installed) instead of being stuck with the device default. The service now also sets the device locale so a fitting voice is chosen.

## Testing

Built and ran on a Pixel 6 (dev flavor). Checked with a long article that the full text is read out, and that pause then play resumes at the right spot both from the in-app player and from the notification. A unit test for the text splitter is included, and `lint`, `test` and `assembleDev` pass locally.

## Notes

Chunk size is deliberately small (200 chars) so resume lands close to where you paused. Because the splitter cuts at sentence ends the pieces still sound natural.
