### PR TITLE
fix: podcast player panel draws under system navigation bar in main feed view

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
@@ -27,6 +27,8 @@ import android.widget.SeekBar;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
@@ -263,6 +265,7 @@ public class PodcastFragment extends Fragment {
             //sliding_layout.setEnableDragViewTouchEvents(true);
 
             sliding_layout.addPanelSlideListener(onPanelSlideListener);
+            applyPodcastInsets();
         }
 
         PodcastFeedArrayAdapter mArrayAdapter = new PodcastFeedArrayAdapter(getActivity(), new PodcastFeedItem[0]);
@@ -277,6 +280,26 @@ public class PodcastFragment extends Fragment {
         binding.sbProgress.setOnSeekBarChangeListener(onSeekBarChangeListener);
 
         return binding.getRoot();
+    }
+
+    private void applyPodcastInsets() {
+        final View root = binding.getRoot();
+        final int rootPaddingLeft = root.getPaddingLeft();
+        final int rootPaddingTop = root.getPaddingTop();
+        final int rootPaddingRight = root.getPaddingRight();
+        final int rootPaddingBottom = root.getPaddingBottom();
+
+        ViewCompat.setOnApplyWindowInsetsListener(sliding_layout, (View v, WindowInsetsCompat insets) -> {
+            var systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            root.setPadding(rootPaddingLeft, rootPaddingTop, rootPaddingRight, rootPaddingBottom + systemBars.bottom);
+
+            if(mActivity instanceof PodcastFragmentActivity) {
+                ((PodcastFragmentActivity) mActivity).setPodcastPanelBottomInset(systemBars.bottom);
+            }
+
+            return insets;
+        });
+        ViewCompat.requestApplyInsets(sliding_layout);
     }
 
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
@@ -64,6 +64,7 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
 
     private EventBus eventBus;
     private PodcastFragment mPodcastFragment;
+    private int podcastPanelBottomInset;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -248,7 +249,22 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
     }
 
     private void expandPodcastView() {
-        getPodcastSlidingUpPanelLayout().setPanelHeight((int) dipToPx(68));
+        getPodcastSlidingUpPanelLayout().setPanelHeight(getVisiblePodcastPanelHeight());
+    }
+
+    void setPodcastPanelBottomInset(int bottomInset) {
+        if(podcastPanelBottomInset == bottomInset) {
+            return;
+        }
+
+        podcastPanelBottomInset = bottomInset;
+        if(getPodcastSlidingUpPanelLayout().getPanelHeight() > 0) {
+            getPodcastSlidingUpPanelLayout().setPanelHeight(getVisiblePodcastPanelHeight());
+        }
+    }
+
+    private int getVisiblePodcastPanelHeight() {
+        return (int) dipToPx(68) + podcastPanelBottomInset;
     }
 
     @Subscribe


### PR DESCRIPTION
## Summary

The collapsed podcast playback panel no longer draws underneath the system navigation bar when playback starts from the main feed view. The bottom system-bar inset is now handled in the shared podcast panel code, so both host activities behave identically under edge-to-edge.

## Why this matters

In #1647, @yukijoou narrowed the repro to playback started from the main feed without opening an article, which is why it did not reproduce at first: `activity_news_detail.xml` sets `fitsSystemWindows` on its root CoordinatorLayout, but `activity_newsreader.xml` only sets it on an inner CoordinatorLayout that does not contain the `PodcastSlidingUpPanelLayout`, leaving the panel flush with the physical screen bottom.

## Changes

- An `OnApplyWindowInsetsListener` on the sliding panel raises the collapsed panel height by the system-bars bottom inset and pads the collapsed header so controls are not clipped.
- `NewsDetailActivity` already consumes the inset via `fitsSystemWindows`, so the listener receives a zero bottom inset there and behavior is unchanged. The root of `activity_newsreader.xml` intentionally keeps its existing edge-to-edge inset handling.

## Testing

Static review against both layout variants (portrait and sw600dp-land); the inset math only adds the reported bottom inset on top of the existing 68dp panel height. A device pass on API 35 edge-to-edge is the remaining verification, which CI/screenshots from the reporter's repro path will exercise.

Fixes #1647

Signed-off-by: Matt Van Horn <455140+mvanhorn@users.noreply.github.com>
