### PR TITLE
Fix loadAppKeyStore

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ssl/MemorizingTrustManager.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ssl/MemorizingTrustManager.java
@@ -291,7 +291,11 @@ public class MemorizingTrustManager implements X509TrustManager {
 					return (X509TrustManager)t;
 				}
 			}
-		} catch (Exception e) {
+try {
+    loadAppKeyStore();
+} catch (Exception e) {
+    Log.e("loadAppKeyStore", "Failed to load App Key Store: " + e);
+}
 			// Here, we are covering up errors. It might be more useful
 			// however to throw them out of the constructor so the
 			// embedding app knows something went wrong.

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ssl/MemorizingTrustManager.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ssl/MemorizingTrustManager.java
@@ -295,24 +295,25 @@ public class MemorizingTrustManager implements X509TrustManager {
 		return null;
 	}
 
-	KeyStore loadAppKeyStore() {
-		KeyStore ks;
+KeyStore loadAppKeyStore() {
+	KeyStore ks;
+	try {
+		ks = KeyStore.getInstance(KeyStore.getDefaultType());
+	} catch (KeyStoreException e) {
+		Log.e(TAG, "getAppKeyStore()", e);
+		return null;
+	}
+	if (keyStoreFile != null) {
 		try {
-			ks = KeyStore.getInstance(KeyStore.getDefaultType());
-		} catch (KeyStoreException e) {
-			Log.e(TAG, "getAppKeyStore()", e);
-			return null;
-		}
-		try {
-			ks.load(null, null);
-			if(keyStoreFile.canRead()) {
-				ks.load(new java.io.FileInputStream(keyStoreFile), "MTM".toCharArray());
-			}
+			ks.load(new java.io.FileInputStream(keyStoreFile), "MTM".toCharArray());
 		} catch (Exception e) {
 			Log.e(TAG, "getAppKeyStore(" + keyStoreFile + ")", e);
 		}
-		return ks;
+	} else {
+		ks.load(null, null);
 	}
+	return ks;
+}
 
 	void storeCert(X509Certificate[] chain) {
 		// add all certs from chain to appKeyStore

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ssl/MemorizingTrustManager.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ssl/MemorizingTrustManager.java
@@ -257,7 +257,12 @@ public class MemorizingTrustManager implements X509TrustManager {
 		try {
 			fos = new java.io.FileOutputStream(keyStoreFile);
 			appKeyStore.store(fos, "MTM".toCharArray());
-		} catch (Exception e) {
+} catch (Exception e) {
+    if (keyStore == null) {
+        keyStore = loadAppKeyStore();
+    }
+    // ...
+}
 			e.printStackTrace();
 			//LOGGER.log(Level.SEVERE, "storeCert(" + keyStoreFile + ")", e);
 		} finally {


### PR DESCRIPTION
# Fix: `loadAppKeyStore`

## Explanation

The error message indicates that the loadAppKeyStore method is not using a valid sequence of method calls when loading a KeyStore, which could be causing the issue. By looking at the code snippet provided, it seems that there is no error handling in place to catch and handle any exceptions that may 

---

## Modified Method

| Property | Value |
|---|---|
| Method | `loadAppKeyStore` |
| Class | `de.luhmer.owncloudnewsreader.ssl.MemorizingTrustManager` |
| File | `/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/de.luhmer.owncloudnewsreader_196.apk/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ssl/MemorizingTrustManager.java` |
| Status | `SUCCESS` |

---

## Changed File

```text
/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/de.luhmer.owncloudnewsreader_196.apk/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ssl/MemorizingTrustManager.java
```

---


## Validation Checklist

- [x] Method replaced in source file
- [x] Repository updated
- [x] Commit generated
- [ ] Manual review required
- [ ] CI validation pending

---

Repair Pipeline