### PR TITLE
fix: don't post podcast notification when no media is loaded

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
@@ -31,6 +31,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
+import androidx.core.app.ServiceCompat;
 import androidx.media.MediaBrowserServiceCompat;
 import androidx.media.session.MediaButtonReceiver;
 
@@ -573,7 +574,7 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
                     .build());
             // Nothing is loaded: remove the notification instead of keeping a
             // stale foreground notification around.
-            stopForeground(true);
+            ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
             podcastNotification.cancel();
         } else {
             currentPosition = mPlaybackService.getCurrentPosition();
@@ -583,7 +584,7 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
             if (playbackState== PlaybackStateCompat.STATE_PLAYING) {
                 startForeground(PodcastNotification.NOTIFICATION_ID, podcastNotification.getNotification());
             } else {
-                stopForeground(false);
+                ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH);
             }
 
             mSession.setPlaybackState(new PlaybackStateCompat.Builder()

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
@@ -133,10 +133,6 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
         return null;
     }
 
-    public boolean isActive() {
-        return mPlaybackService != null;
-    }
-
     static final AtomicLong NEXT_ID = new AtomicLong(0);
     final long id = NEXT_ID.getAndIncrement();
 
@@ -260,15 +256,14 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
     public void onDestroy() {
         Log.v(TAG, "onDestroy PodcastPlaybackService - ID: " + id);
 
-        if (!isActive()) {
-            Log.v(TAG, "Stopping PodcastPlaybackService/PlaybackService because of inactivity");
-            stopSelf();
+        // Cancel the 1s progress tick before releasing the session, otherwise an
+        // already-queued update could run setPlaybackState() on a released session.
+        stopProgressUpdates();
 
-            if (mSession != null) {
-                mSession.release();
-            }
-        } else {
-            Log.v(TAG, "Stopping PlaybackService is not active - skip exit");
+        // Always release the media session on destroy. Leaving it around lets the
+        // system keep routing media buttons here and resurrect the dead service.
+        if (mSession != null) {
+            mSession.release();
         }
 
         try {
@@ -403,12 +398,15 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
             mPlaybackService = null;
         }
 
+        // With no media loaded this runs the STATE_NONE branch, which already
+        // stops the foreground state, deactivates the session and cancels the
+        // notification - so no explicit teardown is needed here.
         syncMediaAndPlaybackStatus();
 
-        Log.d(TAG, "cancel notification");
-        podcastNotification.cancel();
-
         abandonAudioFocus();
+
+        // No media remains, don't keep the service alive idle.
+        stopSelf();
     }
 
     @Subscribe
@@ -491,9 +489,12 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
     }
 
     public void pause() {
-        if(mPlaybackService != null) {
-            mPlaybackService.pause();
+        // Ignore pause events (incoming call, BT/headset button, audio focus loss)
+        // when nothing is loaded, so the idle service doesn't post a notification.
+        if(mPlaybackService == null) {
+            return;
         }
+        mPlaybackService.pause();
         stopProgressUpdates();
 
         abandonAudioFocus();
@@ -570,7 +571,10 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
                     .setState(playbackState, currentPosition, 1.0f)
                     .setActions(buildPlaybackActions(playbackState, false))
                     .build());
-            stopForeground(false);
+            // Nothing is loaded: remove the notification instead of keeping a
+            // stale foreground notification around.
+            stopForeground(true);
+            podcastNotification.cancel();
         } else {
             currentPosition = mPlaybackService.getCurrentPosition();
             totalDuration = mPlaybackService.getTotalDuration();
@@ -777,8 +781,7 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
                 // Stop requested (e.g. notification was swiped away)
                 if(keyEvent.getKeyCode() == KEYCODE_MEDIA_STOP) {
                     pause();
-                    endCurrentMediaPlayback();
-                    stopSelf();
+                    endCurrentMediaPlayback(); // already calls stopSelf()
                     /*
                     boolean isPlaying = mSession.getController().getPlaybackState().getState() == PlaybackStateCompat.STATE_PLAYING;
                     if(isPlaying) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/view/PodcastNotification.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/view/PodcastNotification.java
@@ -50,6 +50,15 @@ public class PodcastNotification {
             return;
         }
 
+        // Don't post a notification when no media is loaded (e.g. idle service).
+        // Otherwise a "00:00 - 00:00" notification appears out of nowhere and
+        // gets re-posted right after the user swipes it away.
+        if (status == PlaybackStateCompat.STATE_NONE) {
+            lastStatus = status;
+            cancel();
+            return;
+        }
+
         if (status != lastStatus) {
             lastStatus = status;
 


### PR DESCRIPTION
The podcast playback service is created and bound whenever any activity is open (PodcastFragment connects a MediaBrowser on every activity start), so the service object is alive for all users, regardless of whether the podcast feature was ever used. syncMediaAndPlaybackStatus() posted/updated the media notification unconditionally, so any idle-service event (incoming phone call, Bluetooth/headset pause button, audio-focus change) produced a phantom "00:00 - 00:00" notification that was re-posted within a second of being swiped away by the 1s progress loop.

Root-cause fixes (localized to the two files):

- PodcastNotification.updateStateOfNotification(): cancel and return when status is STATE_NONE instead of calling notify() unconditionally, so a notification is only shown when media is actually loaded.
- PodcastPlaybackService.syncMediaAndPlaybackStatus(): in the no-media branch use stopForeground(true) and cancel the notification instead of stopForeground(false), which kept a stale foreground notification.
- pause(): early-return when nothing is loaded, so idle pause events (phone ring, BT button, audio-focus loss) no longer trigger a sync/notification.
- onDestroy(): always release the media session (the previous logic only released it when the service was NOT active) and drop the meaningless stopSelf(); endCurrentMediaPlayback() now stopForeground(true), setActive(false) and stopSelf() once no media remains.

Playback, pause-and-swipe-to-stop, and Android Auto play-from-media-id/search behaviour are preserved.

Fixes #796

