### PR TITLE
feat: add "All articles" entry to navigation drawer

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ListView/SubscriptionExpandableListAdapter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ListView/SubscriptionExpandableListAdapter.java
@@ -22,6 +22,7 @@
 package de.luhmer.owncloudnewsreader.ListView;
 
 import static de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_DOWNLOADED_PODCASTS;
+import static de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_ITEMS;
 import static de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_STARRED_ITEMS;
 import static de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_UNREAD_ITEMS;
 import static de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ITEMS_WITHOUT_FOLDER;
@@ -309,6 +310,10 @@ public class SubscriptionExpandableListAdapter extends BaseExpandableListAdapter
                 viewHolder.binding.imgViewExpandableIndicator.setVisibility(View.GONE);
                 viewHolder.binding.imgViewFavicon.setVisibility(View.VISIBLE);
                 viewHolder.binding.imgViewFavicon.setImageResource(R.drawable.ic_baseline_play_arrow_24_theme_aware);
+        	} else if(group.id_database == ALL_ITEMS.getValue()) {
+                viewHolder.binding.imgViewExpandableIndicator.setVisibility(View.GONE);
+                viewHolder.binding.imgViewFavicon.setVisibility(View.VISIBLE);
+                viewHolder.binding.imgViewFavicon.setImageResource(R.drawable.ic_list_24_theme_aware);
         	} else if (getChildrenCount( groupPosition ) == 0 ) {
 	        	viewHolder.binding.imgViewExpandableIndicator.setVisibility(View.GONE);
                 viewHolder.binding.imgViewFavicon.setVisibility(View.INVISIBLE);
@@ -376,6 +381,7 @@ public class SubscriptionExpandableListAdapter extends BaseExpandableListAdapter
 
         ArrayList<AbstractItem> mCategories = new ArrayList<>();
         mCategories.add(new FolderSubscribtionItem(mContext.getString(R.string.allUnreadFeeds), null, ALL_UNREAD_ITEMS.getValue()));
+        mCategories.add(new FolderSubscribtionItem(mContext.getString(R.string.allItems), null, ALL_ITEMS.getValue()));
         mCategories.add(new FolderSubscribtionItem(mContext.getString(R.string.starredFeeds), null, ALL_STARRED_ITEMS.getValue()));
         mCategories.add(new FolderSubscribtionItem(mContext.getString(R.string.downloadedPodcasts), null, ALL_DOWNLOADED_PODCASTS.getValue()));
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -23,6 +23,7 @@ package de.luhmer.owncloudnewsreader;
 
 import static java.util.Objects.requireNonNull;
 import static de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_DOWNLOADED_PODCASTS;
+import static de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_ITEMS;
 import static de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_STARRED_ITEMS;
 import static de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_UNREAD_ITEMS;
 import static de.luhmer.owncloudnewsreader.SettingsActivity.SP_SWIPE_LEFT_ACTION;
@@ -531,7 +532,7 @@ public class NewsReaderDetailFragment extends Fragment {
                 }
                 sqlSelectStatement = dbConn.getAllItemsIdsForFeedSQL(idFeed, onlyUnreadItems, onlyStarredItems, sortDirection);
             } else if (idFolder != null) {
-                if (idFolder == ALL_STARRED_ITEMS.getValue() || idFolder == ALL_DOWNLOADED_PODCASTS.getValue())
+                if (idFolder == ALL_STARRED_ITEMS.getValue() || idFolder == ALL_DOWNLOADED_PODCASTS.getValue() || idFolder == ALL_ITEMS.getValue())
                     onlyUnreadItems = false;
                 sqlSelectStatement = dbConn.getAllItemsIdsForFolderSQL(idFolder, onlyUnreadItems, sortDirection, mActivity);
             }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -779,11 +779,13 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 					return;
 				}
 				title = folder.getLabel();
-			} else if (idFolder == -10) {
+			} else if (idFolder == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_UNREAD_ITEMS.getValue()) {
 				title = getString(R.string.allUnreadFeeds);
-			} else if (idFolder == -11) {
+			} else if (idFolder == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_STARRED_ITEMS.getValue()) {
 				title = getString(R.string.starredFeeds);
-			} else if (idFolder == -13) {
+			} else if (idFolder == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_ITEMS.getValue()) {
+				title = getString(R.string.allItems);
+			} else if (idFolder == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_DOWNLOADED_PODCASTS.getValue()) {
 				title = getString(R.string.downloadedPodcasts);
 			}
 		} else {
@@ -879,11 +881,13 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 			int idFolder = (int) id;
 			if (idFolder >= 0) {
 				title = dbConn.getFolderById(id).getLabel();
-			} else if (idFolder == -10) {
+			} else if (idFolder == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_UNREAD_ITEMS.getValue()) {
 				title = getString(R.string.allUnreadFeeds);
-			} else if (idFolder == -11) {
+			} else if (idFolder == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_STARRED_ITEMS.getValue()) {
 				title = getString(R.string.starredFeeds);
-			} else if (idFolder == -13) {
+			} else if (idFolder == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_ITEMS.getValue()) {
+				title = getString(R.string.allItems);
+			} else if (idFolder == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_DOWNLOADED_PODCASTS.getValue()) {
 				title = getString(R.string.downloadedPodcasts);
 			}
 		}
@@ -967,7 +971,9 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 	private void syncMenuItemUnreadOnly() {
 		if (menuItemOnlyUnread != null && currentFolderId != null) {
-			menuItemOnlyUnread.setVisible(!(currentFolderId == -11 || currentFolderId == -10));
+			menuItemOnlyUnread.setVisible(!(currentFolderId == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_STARRED_ITEMS.getValue()
+					|| currentFolderId == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_UNREAD_ITEMS.getValue()
+					|| currentFolderId == SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_ITEMS.getValue()));
 		}
 	}
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
@@ -608,8 +608,15 @@ public class DatabaseConnectionOrm {
         String buildSQL = "SELECT " + RssItemDao.Properties.Id.columnName +
                 " FROM " + RssItemDao.TABLENAME;
 
-        if(!(ID_FOLDER == ALL_UNREAD_ITEMS.getValue() || ID_FOLDER == ALL_STARRED_ITEMS.getValue() || ID_FOLDER == ALL_DOWNLOADED_PODCASTS.getValue() || ID_FOLDER == ALL_ITEMS.getValue()))//Wenn nicht Alle Artikel ausgewaehlt wurde (-10) oder (-11) fuer Starred Feeds
-        {
+        if (ID_FOLDER == ALL_UNREAD_ITEMS.getValue())
+            buildSQL += " WHERE " + RssItemDao.Properties.Read_temp.columnName + " != 1";
+        else if (ID_FOLDER == ALL_STARRED_ITEMS.getValue())
+            buildSQL += " WHERE " + RssItemDao.Properties.Starred_temp.columnName + " = 1";
+        else if (ID_FOLDER == ALL_DOWNLOADED_PODCASTS.getValue()) {
+            var ids = NewsFileUtils.getDownloadedPodcastsFingerprints(context);
+            var files = Arrays.stream(ids).map((f) -> "\"" + f + "\"").collect(Collectors.toList());
+            buildSQL += " WHERE " + RssItemDao.Properties.Fingerprint.columnName + " in (" + String.join(",", files) + ")";
+        } else if (ID_FOLDER != ALL_ITEMS.getValue()) {
             buildSQL += " WHERE " + RssItemDao.Properties.FeedId.columnName + " IN " +
                     "(SELECT sc." + FeedDao.Properties.Id.columnName +
                     " FROM " + FeedDao.TABLENAME + " sc " +
@@ -621,15 +628,6 @@ public class DatabaseConnectionOrm {
         }
         // ALL_ITEMS (-12) intentionally has no branch here: it shows all articles
         // (read + unread) with no feed or read filter.
-        else if(ID_FOLDER == ALL_UNREAD_ITEMS.getValue())
-            buildSQL += " WHERE " + RssItemDao.Properties.Read_temp.columnName + " != 1";
-        else if(ID_FOLDER == ALL_STARRED_ITEMS.getValue())
-            buildSQL += " WHERE " + RssItemDao.Properties.Starred_temp.columnName + " = 1";
-        else if (ID_FOLDER == ALL_DOWNLOADED_PODCASTS.getValue()) {
-            var ids = NewsFileUtils.getDownloadedPodcastsFingerprints(context);
-            var files = Arrays.stream(ids).map((f) -> "\"" + f + "\"").collect(Collectors.toList());
-            buildSQL += " WHERE " + RssItemDao.Properties.Fingerprint.columnName + " in (" + String.join(",", files) + ")";
-        }
 
         buildSQL += " ORDER BY " + RssItemDao.Properties.PubDate.columnName + " " + sortDirection.toString();
 
@@ -640,8 +638,8 @@ public class DatabaseConnectionOrm {
         String buildSQL = "SELECT " + RssItemDao.Properties.Id.columnName +
                 " FROM " + RssItemDao.TABLENAME;
 
-        if (!(ID_FOLDER == ALL_UNREAD_ITEMS.getValue() || ID_FOLDER == ALL_STARRED_ITEMS.getValue() || ID_FOLDER == ALL_ITEMS.getValue()))//Wenn nicht Alle Artikel ausgewaehlt wurde (-10) oder (-11) fuer Starred Feeds
-        {
+        // Wenn nicht "Alle Artikel" (-12), "Alle ungelesenen Artikel" (-10) oder "Alle markierten Artikel" (-11) ausgewaehlt wurde
+        if (!(ID_FOLDER == ALL_UNREAD_ITEMS.getValue() || ID_FOLDER == ALL_STARRED_ITEMS.getValue() || ID_FOLDER == ALL_ITEMS.getValue())) {
             buildSQL += " WHERE " + RssItemDao.Properties.FeedId.columnName + " IN " +
                     "(SELECT sc." + FeedDao.Properties.Id.columnName +
                     " FROM " + FeedDao.TABLENAME + " sc " +

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
@@ -608,7 +608,7 @@ public class DatabaseConnectionOrm {
         String buildSQL = "SELECT " + RssItemDao.Properties.Id.columnName +
                 " FROM " + RssItemDao.TABLENAME;
 
-        if(!(ID_FOLDER == ALL_UNREAD_ITEMS.getValue() || ID_FOLDER == ALL_STARRED_ITEMS.getValue() || ID_FOLDER == ALL_DOWNLOADED_PODCASTS.getValue()) || ID_FOLDER == ALL_ITEMS.getValue())//Wenn nicht Alle Artikel ausgewaehlt wurde (-10) oder (-11) fuer Starred Feeds
+        if(!(ID_FOLDER == ALL_UNREAD_ITEMS.getValue() || ID_FOLDER == ALL_STARRED_ITEMS.getValue() || ID_FOLDER == ALL_DOWNLOADED_PODCASTS.getValue() || ID_FOLDER == ALL_ITEMS.getValue()))//Wenn nicht Alle Artikel ausgewaehlt wurde (-10) oder (-11) fuer Starred Feeds
         {
             buildSQL += " WHERE " + RssItemDao.Properties.FeedId.columnName + " IN " +
                     "(SELECT sc." + FeedDao.Properties.Id.columnName +
@@ -619,6 +619,8 @@ public class DatabaseConnectionOrm {
             if(onlyUnread)
                 buildSQL += " AND " + RssItemDao.Properties.Read_temp.columnName + " != 1";
         }
+        // ALL_ITEMS (-12) intentionally has no branch here: it shows all articles
+        // (read + unread) with no feed or read filter.
         else if(ID_FOLDER == ALL_UNREAD_ITEMS.getValue())
             buildSQL += " WHERE " + RssItemDao.Properties.Read_temp.columnName + " != 1";
         else if(ID_FOLDER == ALL_STARRED_ITEMS.getValue())
@@ -638,7 +640,7 @@ public class DatabaseConnectionOrm {
         String buildSQL = "SELECT " + RssItemDao.Properties.Id.columnName +
                 " FROM " + RssItemDao.TABLENAME;
 
-        if (!(ID_FOLDER == ALL_UNREAD_ITEMS.getValue() || ID_FOLDER == ALL_STARRED_ITEMS.getValue()) || ID_FOLDER == ALL_ITEMS.getValue())//Wenn nicht Alle Artikel ausgewaehlt wurde (-10) oder (-11) fuer Starred Feeds
+        if (!(ID_FOLDER == ALL_UNREAD_ITEMS.getValue() || ID_FOLDER == ALL_STARRED_ITEMS.getValue() || ID_FOLDER == ALL_ITEMS.getValue()))//Wenn nicht Alle Artikel ausgewaehlt wurde (-10) oder (-11) fuer Starred Feeds
         {
             buildSQL += " WHERE " + RssItemDao.Properties.FeedId.columnName + " IN " +
                     "(SELECT sc." + FeedDao.Properties.Id.columnName +
@@ -684,6 +686,8 @@ public class DatabaseConnectionOrm {
 
         if(specialFolder != null && specialFolder.equals(SPECIAL_FOLDERS.ALL_STARRED_ITEMS)) {
             buildSQL += " WHERE " + RssItemDao.Properties.Starred_temp.columnName + " = 1 ";
+        } else if(specialFolder != null && specialFolder.equals(SPECIAL_FOLDERS.ALL_ITEMS)) {
+            // "All articles" shows read + unread items, so count every item (no filter)
         } else {
             buildSQL += " WHERE " + RssItemDao.Properties.Read_temp.columnName + " != 1 ";
         }
@@ -738,6 +742,7 @@ public class DatabaseConnectionOrm {
 
 
         values[0].put(SPECIAL_FOLDERS.ALL_UNREAD_ITEMS.getValue(), String.valueOf(totalUnreadItemsCount));
+        values[0].put(SPECIAL_FOLDERS.ALL_ITEMS.getValue(), getUnreadItemsCountForSpecificFolder(SPECIAL_FOLDERS.ALL_ITEMS));
         values[0].put(SPECIAL_FOLDERS.ALL_STARRED_ITEMS.getValue(), getUnreadItemsCountForSpecificFolder(SPECIAL_FOLDERS.ALL_STARRED_ITEMS));
 
 

--- a/News-Android-App/src/main/res/drawable/ic_list_24_theme_aware.xml
+++ b/News-Android-App/src/main/res/drawable/ic_list_24_theme_aware.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24"
+        android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,13h2v-2H3V13zM3,17h2v-2H3V17zM3,9h2V7H3V9zM7,13h14v-2H7V13zM7,17h14v-2H7V17zM7,7v2h14V7H7z"/>
+</vector>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     </plurals>
     <string name="message_bar_reload">Reload</string>
     <string name="allUnreadFeeds">All unread items</string>
-    <string name="allItems">All articles</string>
+    <string name="allItems">All local articles</string>
     <string name="starredFeeds">Starred items</string>
     <string name="downloadedPodcasts">Downloaded podcasts</string>
     <string name="title_activity_new_feed">Add new feed</string>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     </plurals>
     <string name="message_bar_reload">Reload</string>
     <string name="allUnreadFeeds">All unread items</string>
+    <string name="allItems">All articles</string>
     <string name="starredFeeds">Starred items</string>
     <string name="downloadedPodcasts">Downloaded podcasts</string>
     <string name="title_activity_new_feed">Add new feed</string>


### PR DESCRIPTION
Surface the existing (but never shown) ALL_ITEMS (-12) special folder as an "All articles" row in the navigation drawer, giving parity with the Nextcloud News web UI sidebar. The view always shows read + unread articles, independent of the global "show only unread" filter.

Changes:
- Add "All articles" drawer row + theme-aware list icon.
- Fix the ALL_ITEMS SQL: the -12 check was outside the negated group in getAllItemsIdsForFolderSQL / ...SQLSearch, so the view matched nothing. ALL_ITEMS now emits no feed/read filter (read + unread).
- Inject the total unread count for -12 so the row shows a badge and is not pruned when "show only unread" is on.
- Force onlyUnreadItems = false for ALL_ITEMS in the detail fragment.
- Map the "-12" title and hide the unread-only toggle in this view.

refs #1001, refs #1648, refs #400

