### PR TITLE
feat: remember podcast playback position

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
@@ -41,6 +41,7 @@ import de.luhmer.owncloudnewsreader.database.model.RssItem;
 import de.luhmer.owncloudnewsreader.database.model.RssItemDao;
 import de.luhmer.owncloudnewsreader.helper.AsyncTaskHelper;
 import de.luhmer.owncloudnewsreader.helper.NewsFileUtils;
+import de.luhmer.owncloudnewsreader.helper.PodcastPositionStore;
 import de.luhmer.owncloudnewsreader.helper.StopWatch;
 import de.luhmer.owncloudnewsreader.model.PodcastFeedItem;
 import de.luhmer.owncloudnewsreader.model.PodcastItem;
@@ -80,6 +81,7 @@ public class DatabaseConnectionOrm {
         daoSession.getFeedDao().deleteAll();
         daoSession.getFolderDao().deleteAll();
         daoSession.getCurrentRssItemViewDao().deleteAll();
+        new PodcastPositionStore(context).clearAll();
     }
 
     public DatabaseConnectionOrm(Context context) {
@@ -802,6 +804,37 @@ public class DatabaseConnectionOrm {
         } else {
             Log.v(TAG, "Clearing Database oversize not necessary");
         }
+
+        clearStalePodcastPositions();
+    }
+
+    /**
+     * Removes stored podcast playback positions (see issue #504) of rss items
+     * that no longer exist in the database.
+     */
+    private void clearStalePodcastPositions() {
+        PodcastPositionStore positionStore = new PodcastPositionStore(context);
+        List<Long> storedItemIds = positionStore.getStoredItemIds();
+        if (storedItemIds.isEmpty()) {
+            return;
+        }
+
+        // Resolve which of the stored ids still exist in a single query instead
+        // of one lookup per stored position.
+        Set<Long> existingIds = new HashSet<>();
+        for (RssItem item : daoSession.getRssItemDao().queryBuilder()
+                .where(RssItemDao.Properties.Id.in(storedItemIds))
+                .list()) {
+            existingIds.add(item.getId());
+        }
+
+        List<Long> staleItemIds = new ArrayList<>();
+        for (Long itemId : storedItemIds) {
+            if (!existingIds.contains(itemId)) {
+                staleItemIds.add(itemId);
+            }
+        }
+        positionStore.removePositions(staleItemIds);
     }
 
     public long getLastModified()

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/PodcastPositionStore.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/PodcastPositionStore.java
@@ -1,0 +1,98 @@
+package de.luhmer.owncloudnewsreader.helper;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Remembers the last playback position of podcast episodes (see issue #504).
+ *
+ * Positions are kept in a dedicated SharedPreferences file (not the main
+ * settings file) keyed by rss item id. The item fingerprint is stored
+ * alongside the position so a stale entry is ignored when the enclosure
+ * changed or the item id belongs to a different account.
+ */
+public class PodcastPositionStore {
+
+    private static final String TAG = PodcastPositionStore.class.getCanonicalName();
+
+    private static final String PREF_FILE_SUFFIX = "_podcast_positions";
+    private static final String KEY_PREFIX = "pos_";
+    private static final String SEPARATOR = "|";
+
+    private final SharedPreferences mPrefs;
+
+    public PodcastPositionStore(Context context) {
+        mPrefs = context.getSharedPreferences(context.getPackageName() + PREF_FILE_SUFFIX, Context.MODE_PRIVATE);
+    }
+
+    /**
+     * @return the stored position in milliseconds, or 0 if there is no valid
+     *         stored position for this item / fingerprint combination.
+     */
+    public long getPosition(long itemId, String fingerprint) {
+        String value = mPrefs.getString(KEY_PREFIX + itemId, null);
+        if (value == null) {
+            return 0;
+        }
+
+        String[] parts = value.split("\\" + SEPARATOR, 3);
+        if (parts.length != 3) {
+            return 0;
+        }
+
+        try {
+            long position = Long.parseLong(parts[0]);
+            long duration = Long.parseLong(parts[1]);
+            if (position <= 0 || position >= duration || !parts[2].equals(fingerprint)) {
+                return 0;
+            }
+            return position;
+        } catch (NumberFormatException e) {
+            Log.w(TAG, "Ignoring invalid stored podcast position: " + value);
+            return 0;
+        }
+    }
+
+    public void savePosition(long itemId, String fingerprint, long positionMillis, long durationMillis) {
+        String value = positionMillis + SEPARATOR + durationMillis + SEPARATOR + fingerprint;
+        mPrefs.edit().putString(KEY_PREFIX + itemId, value).apply();
+    }
+
+    public void clearPosition(long itemId) {
+        mPrefs.edit().remove(KEY_PREFIX + itemId).apply();
+    }
+
+    public void clearAll() {
+        mPrefs.edit().clear().apply();
+    }
+
+    public List<Long> getStoredItemIds() {
+        List<Long> itemIds = new ArrayList<>();
+        for (String key : mPrefs.getAll().keySet()) {
+            if (key.startsWith(KEY_PREFIX)) {
+                try {
+                    itemIds.add(Long.parseLong(key.substring(KEY_PREFIX.length())));
+                } catch (NumberFormatException e) {
+                    Log.w(TAG, "Ignoring invalid podcast position key: " + key);
+                }
+            }
+        }
+        return itemIds;
+    }
+
+    public void removePositions(Collection<Long> itemIds) {
+        if (itemIds.isEmpty()) {
+            return;
+        }
+        SharedPreferences.Editor editor = mPrefs.edit();
+        for (Long itemId : itemIds) {
+            editor.remove(KEY_PREFIX + itemId);
+        }
+        editor.apply();
+    }
+}

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
@@ -57,6 +57,7 @@ import de.luhmer.owncloudnewsreader.events.podcast.SeekPodcast;
 import de.luhmer.owncloudnewsreader.events.podcast.SpeedPodcast;
 import de.luhmer.owncloudnewsreader.events.podcast.TogglePlayerStateEvent;
 import de.luhmer.owncloudnewsreader.events.podcast.WindPodcast;
+import de.luhmer.owncloudnewsreader.helper.PodcastPositionStore;
 import de.luhmer.owncloudnewsreader.model.MediaItem;
 import de.luhmer.owncloudnewsreader.model.PodcastFeedItem;
 import de.luhmer.owncloudnewsreader.model.PodcastItem;
@@ -106,7 +107,15 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
     private static final long PROGRESS_UPDATE_INTERNAL = 1000;
     private static final long PROGRESS_UPDATE_INITIAL_INTERVAL = 100;
 
+    // resume position handling (issue #504)
+    private static final long POSITION_SAVE_INTERVAL = 5000;
+    private static final long POSITION_MIN_SAVE_POSITION = 5000;
+    private static final long POSITION_COMPLETED_REMAINING = 15000;
+    private static final float POSITION_COMPLETED_PERCENT = 0.95f;
+
     private PodcastNotification podcastNotification;
+    private PodcastPositionStore mPositionStore;
+    private long mLastPositionSaveTime = 0;
 
     private EventBus eventBus;
     private Handler mHandler;
@@ -235,6 +244,7 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
         initMediaSessions();
 
         podcastNotification = new PodcastNotification(this, mSession);
+        mPositionStore = new PodcastPositionStore(this);
         mHandler = new Handler();
         eventBus = EventBus.getDefault();
         eventBus.register(this);
@@ -307,9 +317,14 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
         }
 
         if (mPlaybackService != null) {
+            persistPlaybackPosition(); // remember position when switching episodes
             mPlaybackService.destroy();
             mPlaybackService = null;
         }
+
+        // reset the throttle so the new episode's first periodic save is a full
+        // interval in, not carried over from the previous episode
+        mLastPositionSaveTime = 0;
 
         stopProgressUpdates();
 
@@ -319,7 +334,9 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
             //if (((PodcastItem) mediaItem).isYoutubeVideo()) {
             //    mPlaybackService = new YoutubePlaybackService(this, podcastStatusListener, mediaItem);
             //} else {
-                mPlaybackService = new MediaPlayerPlaybackService(this, podcastStatusListener, mediaItem);
+                PodcastItem podcastItem = (PodcastItem) mediaItem;
+                int startPosition = (int) mPositionStore.getPosition(podcastItem.itemId, podcastItem.fingerprint);
+                mPlaybackService = new MediaPlayerPlaybackService(this, podcastStatusListener, mediaItem, startPosition);
             //}
         } else if (mediaItem instanceof TTSItem) {
             mPlaybackService = new TTSPlaybackService(this, podcastStatusListener, mediaItem);
@@ -385,7 +402,16 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
         public void podcastCompleted() {
             Log.d(TAG, "Podcast completed, cleaning up");
 
+            MediaItem mediaItem = getCurrentlyPlayingPodcast();
+
             endCurrentMediaPlayback();
+
+            // Episode finished: forget any stored position so it starts from the
+            // beginning next time. Done after teardown so it always wins over the
+            // position persist that runs inside endCurrentMediaPlayback().
+            if (mediaItem instanceof PodcastItem) {
+                mPositionStore.clearPosition(mediaItem.itemId);
+            }
 
             EventBus.getDefault().post(new PodcastCompletedEvent());
         }
@@ -393,6 +419,7 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
 
     private void endCurrentMediaPlayback() {
         Log.d(TAG, "endCurrentMediaPlayback() called");
+        persistPlaybackPosition();
         stopProgressUpdates();
 
         // Set metadata
@@ -409,6 +436,34 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
         podcastNotification.cancel();
 
         abandonAudioFocus();
+    }
+
+    /**
+     * Remembers the current playback position of the active podcast so it can
+     * be resumed later (issue #504). Clears the stored position instead when
+     * the episode is (almost) finished.
+     */
+    private void persistPlaybackPosition() {
+        if (!(mPlaybackService instanceof MediaPlayerPlaybackService)) {
+            return; // e.g. TTS playback
+        }
+
+        MediaItem mediaItem = mPlaybackService.getMediaItem();
+        if (!(mediaItem instanceof PodcastItem) || !mPlaybackService.isMediaLoaded()) {
+            return;
+        }
+
+        long position = mPlaybackService.getCurrentPosition();
+        long duration = mPlaybackService.getTotalDuration();
+        if (duration <= 0) {
+            return; // e.g. live streams
+        }
+
+        if (position >= duration * POSITION_COMPLETED_PERCENT || position >= duration - POSITION_COMPLETED_REMAINING) {
+            mPositionStore.clearPosition(mediaItem.itemId);
+        } else if (position >= POSITION_MIN_SAVE_POSITION) {
+            mPositionStore.savePosition(mediaItem.itemId, ((PodcastItem) mediaItem).fingerprint, position, duration);
+        }
     }
 
     @Subscribe
@@ -493,6 +548,7 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
     public void pause() {
         if(mPlaybackService != null) {
             mPlaybackService.pause();
+            persistPlaybackPosition();
         }
         stopProgressUpdates();
 
@@ -575,6 +631,12 @@ public class PodcastPlaybackService extends MediaBrowserServiceCompat {
             currentPosition = mPlaybackService.getCurrentPosition();
             totalDuration = mPlaybackService.getTotalDuration();
             playbackState = mPlaybackService.getStatus();
+
+            if (playbackState == PlaybackStateCompat.STATE_PLAYING
+                    && System.currentTimeMillis() - mLastPositionSaveTime >= POSITION_SAVE_INTERVAL) {
+                mLastPositionSaveTime = System.currentTimeMillis();
+                persistPlaybackPosition();
+            }
 
             if (playbackState== PlaybackStateCompat.STATE_PLAYING) {
                 startForeground(PodcastNotification.NOTIFICATION_ID, podcastNotification.getNotification());

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/podcast/MediaPlayerPlaybackService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/podcast/MediaPlayerPlaybackService.java
@@ -23,7 +23,7 @@ public class MediaPlayerPlaybackService extends PlaybackService {
     private final MediaPlayer mMediaPlayer;
     //private View parentView;
 
-    public MediaPlayerPlaybackService(final Context context, PodcastStatusListener podcastStatusListener, MediaItem mediaItem) {
+    public MediaPlayerPlaybackService(final Context context, PodcastStatusListener podcastStatusListener, MediaItem mediaItem, final int startPositionMillis) {
         super(podcastStatusListener, mediaItem);
 
         mMediaPlayer = new MediaPlayer();
@@ -42,7 +42,19 @@ public class MediaPlayerPlaybackService extends PlaybackService {
         mMediaPlayer.setOnPreparedListener(mediaPlayer -> {
             podcastStatusListener.podcastStatusUpdated();
             setStatus(PlaybackStateCompat.STATE_PAUSED);
-            play();
+
+            // resume where the user left off last time (issue #504). seekTo() is
+            // async - especially for streamed episodes - so wait for it to land
+            // before starting playback, otherwise we'd briefly play from 0.
+            if (startPositionMillis > 0 && startPositionMillis < mediaPlayer.getDuration()) {
+                mediaPlayer.setOnSeekCompleteListener(mp -> {
+                    mp.setOnSeekCompleteListener(null);
+                    play();
+                });
+                mediaPlayer.seekTo(startPositionMillis);
+            } else {
+                play();
+            }
         });
 
         mMediaPlayer.setOnCompletionListener(mediaPlayer -> {

--- a/News-Android-App/src/test/java/de/luhmer/owncloudnewsreader/junit_tests/PodcastPositionStoreTest.java
+++ b/News-Android-App/src/test/java/de/luhmer/owncloudnewsreader/junit_tests/PodcastPositionStoreTest.java
@@ -1,0 +1,68 @@
+package de.luhmer.owncloudnewsreader.junit_tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import de.luhmer.owncloudnewsreader.helper.PodcastPositionStore;
+
+@RunWith(RobolectricTestRunner.class)
+public class PodcastPositionStoreTest {
+
+    private static final String FINGERPRINT = "abc-123";
+
+    private PodcastPositionStore store;
+
+    @Before
+    public void setUp() {
+        store = new PodcastPositionStore(RuntimeEnvironment.getApplication());
+        store.clearAll();
+    }
+
+    @Test
+    public void testSaveAndRestore() {
+        store.savePosition(42L, FINGERPRINT, 90_000, 3_600_000);
+        assertEquals(90_000, store.getPosition(42L, FINGERPRINT));
+    }
+
+    @Test
+    public void testMissingEntryReturnsZero() {
+        assertEquals(0, store.getPosition(42L, FINGERPRINT));
+    }
+
+    @Test
+    public void testFingerprintMismatchInvalidatesPosition() {
+        store.savePosition(42L, FINGERPRINT, 90_000, 3_600_000);
+        assertEquals(0, store.getPosition(42L, "other-fingerprint"));
+    }
+
+    @Test
+    public void testImplausiblePositionReturnsZero() {
+        // position beyond the stored duration must be ignored
+        store.savePosition(42L, FINGERPRINT, 3_700_000, 3_600_000);
+        assertEquals(0, store.getPosition(42L, FINGERPRINT));
+    }
+
+    @Test
+    public void testClearPosition() {
+        store.savePosition(42L, FINGERPRINT, 90_000, 3_600_000);
+        store.clearPosition(42L);
+        assertEquals(0, store.getPosition(42L, FINGERPRINT));
+    }
+
+    @Test
+    public void testRemovePositions() {
+        store.savePosition(1L, FINGERPRINT, 90_000, 3_600_000);
+        store.savePosition(2L, FINGERPRINT, 90_000, 3_600_000);
+        assertEquals(2, store.getStoredItemIds().size());
+
+        store.removePositions(store.getStoredItemIds());
+        assertTrue(store.getStoredItemIds().isEmpty());
+        assertEquals(0, store.getPosition(1L, FINGERPRINT));
+    }
+}


### PR DESCRIPTION
Stores the playback position of podcast episodes in a dedicated SharedPreferences file (no database schema change) so playback resumes where the user left off - across pause, episode switches, app restarts and crashes. The stored entry is validated against the item fingerprint and cleared once an episode is (almost) finished. Stale entries are pruned during the regular sync cleanup and on account switch.

Covers the resume part of #504. Marking audio articles as read only after listening (also requested there) is intentionally not included.

