### PR TITLE
fix: podcast player is drawn under the system bars

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
@@ -27,6 +27,8 @@ import android.widget.SeekBar;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
@@ -263,6 +265,7 @@ public class PodcastFragment extends Fragment {
             //sliding_layout.setEnableDragViewTouchEvents(true);
 
             sliding_layout.addPanelSlideListener(onPanelSlideListener);
+            applyPodcastInsets();
         }
 
         PodcastFeedArrayAdapter mArrayAdapter = new PodcastFeedArrayAdapter(getActivity(), new PodcastFeedItem[0]);
@@ -277,6 +280,26 @@ public class PodcastFragment extends Fragment {
         binding.sbProgress.setOnSeekBarChangeListener(onSeekBarChangeListener);
 
         return binding.getRoot();
+    }
+
+    private void applyPodcastInsets() {
+        final View root = binding.getRoot();
+        final int rootPaddingLeft = root.getPaddingLeft();
+        final int rootPaddingTop = root.getPaddingTop();
+        final int rootPaddingRight = root.getPaddingRight();
+        final int rootPaddingBottom = root.getPaddingBottom();
+
+        ViewCompat.setOnApplyWindowInsetsListener(sliding_layout, (View v, WindowInsetsCompat insets) -> {
+            var systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            root.setPadding(rootPaddingLeft, rootPaddingTop, rootPaddingRight, rootPaddingBottom + systemBars.bottom);
+
+            if(mActivity instanceof PodcastFragmentActivity) {
+                ((PodcastFragmentActivity) mActivity).setPodcastPanelBottomInset(systemBars.bottom);
+            }
+
+            return insets;
+        });
+        ViewCompat.requestApplyInsets(sliding_layout);
     }
 
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
@@ -84,6 +84,9 @@ public class PodcastFragment extends Fragment {
     private long currentPositionInMillis = 0;
     private long maxPositionInMillis = 100000;
 
+    private int panelTopInset = 0;
+    private int panelBottomInset = 0;
+
     protected FragmentPodcastBinding binding;
 
     /**
@@ -228,9 +231,11 @@ public class PodcastFragment extends Fragment {
             if (newState == SlidingUpPanelLayout.PanelState.COLLAPSED) {
                 sliding_layout.setDragView(binding.llPodcastHeader);
                 binding.viewSwitcherProgress.setDisplayedChild(0);
+                applyPodcastHeaderInsets();
             } else if (newState == SlidingUpPanelLayout.PanelState.EXPANDED) {
                 sliding_layout.setDragView(binding.viewSwitcherProgress);
                 binding.viewSwitcherProgress.setDisplayedChild(1);
+                applyPodcastHeaderInsets();
             }
         }
     };
@@ -282,12 +287,18 @@ public class PodcastFragment extends Fragment {
         return binding.getRoot();
     }
 
+    /**
+     * The panel spans the whole window in {@link NewsReaderListActivity}, so it has to keep clear of
+     * the system bars on its own. {@link NewsDetailActivity} positions it below the toolbar already,
+     * which is why only the part of the status bar that is left over is taken into account.
+     */
     private void applyPodcastInsets() {
         final View root = binding.getRoot();
         final int rootPaddingLeft = root.getPaddingLeft();
         final int rootPaddingTop = root.getPaddingTop();
         final int rootPaddingRight = root.getPaddingRight();
         final int rootPaddingBottom = root.getPaddingBottom();
+        final int slidingLayoutTop = ((ViewGroup.MarginLayoutParams) sliding_layout.getLayoutParams()).topMargin;
 
         ViewCompat.setOnApplyWindowInsetsListener(sliding_layout, (View v, WindowInsetsCompat insets) -> {
             var systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
@@ -297,9 +308,30 @@ public class PodcastFragment extends Fragment {
                 ((PodcastFragmentActivity) mActivity).setPodcastPanelBottomInset(systemBars.bottom);
             }
 
+            panelTopInset = Math.max(0, systemBars.top - slidingLayoutTop);
+            panelBottomInset = systemBars.bottom;
+            applyPodcastHeaderInsets();
+
             return insets;
         });
         ViewCompat.requestApplyInsets(sliding_layout);
+    }
+
+    /**
+     * The header is the only part of the panel that is visible while it is collapsed, so it is the
+     * one that touches the bottom of the screen then - and the top of it once the panel is expanded.
+     * It grows by the inset of that edge, so that its background reaches behind the system bar while
+     * the playback controls stay clear of it.
+     */
+    private void applyPodcastHeaderInsets() {
+        boolean expanded = sliding_layout.getPanelState() == SlidingUpPanelLayout.PanelState.EXPANDED;
+        int top = expanded ? panelTopInset : 0;
+        int bottom = expanded ? 0 : panelBottomInset;
+
+        final View header = binding.viewSwitcherProgress;
+        header.setPadding(0, top, 0, bottom);
+        header.getLayoutParams().height = getResources().getDimensionPixelSize(R.dimen.podcast_header_height) + top + bottom;
+        header.requestLayout();
     }
 
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
@@ -64,6 +64,7 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
 
     private EventBus eventBus;
     private PodcastFragment mPodcastFragment;
+    private int podcastPanelBottomInset;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -248,7 +249,22 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
     }
 
     private void expandPodcastView() {
-        getPodcastSlidingUpPanelLayout().setPanelHeight((int) dipToPx(68));
+        getPodcastSlidingUpPanelLayout().setPanelHeight(getVisiblePodcastPanelHeight());
+    }
+
+    void setPodcastPanelBottomInset(int bottomInset) {
+        if(podcastPanelBottomInset == bottomInset) {
+            return;
+        }
+
+        podcastPanelBottomInset = bottomInset;
+        if(getPodcastSlidingUpPanelLayout().getPanelHeight() > 0) {
+            getPodcastSlidingUpPanelLayout().setPanelHeight(getVisiblePodcastPanelHeight());
+        }
+    }
+
+    private int getVisiblePodcastPanelHeight() {
+        return (int) dipToPx(68) + podcastPanelBottomInset;
     }
 
     @Subscribe

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
@@ -11,7 +11,6 @@ import android.os.Bundle;
 import android.support.v4.media.session.MediaControllerCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
 import android.util.Log;
-import android.util.TypedValue;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
@@ -264,7 +263,8 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
     }
 
     private int getVisiblePodcastPanelHeight() {
-        return (int) dipToPx(68) + podcastPanelBottomInset;
+        // has to match the header of the panel, which is all that is visible while collapsed
+        return getResources().getDimensionPixelSize(R.dimen.podcast_header_height) + podcastPanelBottomInset;
     }
 
     @Subscribe
@@ -276,10 +276,6 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
 
     public static int pxToDp(int px) {
         return (int) (px / Resources.getSystem().getDisplayMetrics().density);
-    }
-
-    private float dipToPx(@SuppressWarnings("SameParameterValue") float dip) {
-        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dip, getResources().getDisplayMetrics());
     }
 
     @VisibleForTesting

--- a/News-Android-App/src/main/res/layout/fragment_podcast.xml
+++ b/News-Android-App/src/main/res/layout/fragment_podcast.xml
@@ -7,14 +7,14 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#fff">
+    android:background="?attr/colorSecondaryContainer">
 
 
     <!-- HEADER -->
     <ViewSwitcher
         android:id="@+id/viewSwitcherProgress"
         android:layout_width="match_parent"
-        android:layout_height="68dp"
+        android:layout_height="@dimen/podcast_header_height"
         android:inAnimation="@android:anim/fade_in"
         android:outAnimation="@android:anim/fade_out">
 
@@ -168,6 +168,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dip"
         android:layout_weight="1"
+        android:background="#fff"
         android:paddingStart="@dimen/podcast_horizontal_margin"
         android:paddingEnd="@dimen/podcast_horizontal_margin">
         <!--

--- a/News-Android-App/src/main/res/values/dimens.xml
+++ b/News-Android-App/src/main/res/values/dimens.xml
@@ -17,6 +17,7 @@
 
     <dimen name="podcast_horizontal_margin">16dp</dimen>
 
+    <dimen name="podcast_header_height">68dp</dimen>
     <dimen name="podcast_media_control_height">80dp</dimen>
 
     <dimen name="empty_content_font_size">26sp</dimen>

--- a/News-Android-App/src/test/java/de/luhmer/owncloudnewsreader/junit_tests/PodcastPanelInsetsTest.java
+++ b/News-Android-App/src/test/java/de/luhmer/owncloudnewsreader/junit_tests/PodcastPanelInsetsTest.java
@@ -1,0 +1,180 @@
+package de.luhmer.owncloudnewsreader.junit_tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.ViewSwitcher;
+
+import com.sothree.slidinguppanel.SlidingUpPanelLayout;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import de.luhmer.owncloudnewsreader.R;
+
+/**
+ * Verifies that the podcast panel keeps clear of the system bars, see
+ * <a href="https://github.com/nextcloud/news-android/issues/1647">#1647</a>. The panel spans the
+ * whole window in {@code activity_newsreader}, while {@code activity_news_detail} positions it below
+ * the toolbar - both are checked here.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(qualifiers = "w360dp-h740dp-xxhdpi")
+public class PodcastPanelInsetsTest {
+
+    private static final int WINDOW_WIDTH = 1080;
+    private static final int WINDOW_HEIGHT = 2400;
+    private static final int STATUS_BAR_INSET = 130;
+    private static final int NAVIGATION_BAR_INSET = 60;
+
+    private Activity activity;
+    private View activityRoot;
+    private SlidingUpPanelLayout slidingLayout;
+    private View panel;
+    private View panelContent;
+
+    /**
+     * Builds the given activity layout including the podcast fragment layout and applies the insets
+     * the way {@code PodcastFragment} and {@code PodcastFragmentActivity} do at runtime.
+     */
+    private void inflate(int activityLayout, SlidingUpPanelLayout.PanelState panelState) {
+        activity = Robolectric.buildActivity(Activity.class).setup().get();
+        activity.setTheme(R.style.AppTheme);
+
+        LayoutInflater inflater = LayoutInflater.from(activity);
+        // the <fragment> tags are of no interest here, but need a stand in to be inflatable
+        inflater.setFactory2(new LayoutInflater.Factory2() {
+            @Override
+            public View onCreateView(View parent, String name, Context context, AttributeSet attrs) {
+                return onCreateView(name, context, attrs);
+            }
+
+            @Override
+            public View onCreateView(String name, Context context, AttributeSet attrs) {
+                return "fragment".equals(name) ? new FrameLayout(context) : null;
+            }
+        });
+
+        activityRoot = inflater.inflate(activityLayout, null);
+        slidingLayout = activityRoot.findViewById(R.id.sliding_layout);
+        panel = activityRoot.findViewById(R.id.podcast_frame);
+
+        panelContent = LayoutInflater.from(activity).inflate(R.layout.fragment_podcast, null);
+        ((ViewGroup) panel).addView(panelContent);
+
+        slidingLayout.setPanelState(panelState);
+
+        // PodcastFragmentActivity lifts the collapsed mini player above the navigation bar
+        slidingLayout.setPanelHeight(headerHeight() + NAVIGATION_BAR_INSET);
+        // ... and PodcastFragment keeps the media controls of the expanded player clear of it
+        panelContent.setPadding(0, 0, 0, NAVIGATION_BAR_INSET);
+        // ... and grows the header by the inset of whichever screen edge it touches
+        int slidingLayoutTop = ((ViewGroup.MarginLayoutParams) slidingLayout.getLayoutParams()).topMargin;
+        boolean expanded = panelState == SlidingUpPanelLayout.PanelState.EXPANDED;
+        // the header swaps its content along with the panel state
+        ((ViewSwitcher) header()).setDisplayedChild(expanded ? 1 : 0);
+        int headerTop = expanded ? Math.max(0, STATUS_BAR_INSET - slidingLayoutTop) : 0;
+        int headerBottom = expanded ? 0 : NAVIGATION_BAR_INSET;
+        header().setPadding(0, headerTop, 0, headerBottom);
+        header().getLayoutParams().height = headerHeight() + headerTop + headerBottom;
+
+        activityRoot.measure(
+                View.MeasureSpec.makeMeasureSpec(WINDOW_WIDTH, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(WINDOW_HEIGHT, View.MeasureSpec.EXACTLY));
+        activityRoot.layout(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
+    }
+
+    private int headerHeight() {
+        return activity.getResources().getDimensionPixelSize(R.dimen.podcast_header_height);
+    }
+
+    /** Position of the given view within the window. */
+    private int topInWindow(View view) {
+        int top = 0;
+        for (View current = view; current != activityRoot; current = (View) current.getParent()) {
+            top += current.getTop();
+        }
+        return top;
+    }
+
+    private View header() {
+        return panelContent.findViewById(R.id.viewSwitcherProgress);
+    }
+
+    private View playbackButton() {
+        return panelContent.findViewById(R.id.btn_playPausePodcastSlider);
+    }
+
+    /** Wrapper of the mini player play button, which spans the whole content of the header. */
+    private View miniPlayerButton() {
+        return panelContent.findViewById(R.id.fl_playPausePodcastWrapper);
+    }
+
+    private View expandedTitle() {
+        return panelContent.findViewById(R.id.tv_titleSlider);
+    }
+
+    private void assertPlaybackControlsAboveNavigationBar() {
+        assertTrue("playback controls must stay above the navigation bar",
+                topInWindow(playbackButton()) + playbackButton().getHeight()
+                        <= WINDOW_HEIGHT - NAVIGATION_BAR_INSET);
+    }
+
+    @Test
+    public void collapsedMiniPlayerSitsAboveTheNavigationBar() {
+        inflate(R.layout.activity_newsreader, SlidingUpPanelLayout.PanelState.COLLAPSED);
+
+        assertEquals(headerHeight(), miniPlayerButton().getHeight());
+        assertEquals(WINDOW_HEIGHT - NAVIGATION_BAR_INSET,
+                topInWindow(miniPlayerButton()) + miniPlayerButton().getHeight());
+    }
+
+    @Test
+    public void collapsedHeaderFillsTheNavigationBarArea() {
+        inflate(R.layout.activity_newsreader, SlidingUpPanelLayout.PanelState.COLLAPSED);
+
+        // nothing but the header may show up behind the navigation bar
+        assertEquals(WINDOW_HEIGHT, topInWindow(header()) + header().getHeight());
+    }
+
+    @Test
+    public void expandedPlayerSitsBetweenTheSystemBars() {
+        inflate(R.layout.activity_newsreader, SlidingUpPanelLayout.PanelState.EXPANDED);
+
+        // the panel covers the status bar, the header content starts below it
+        assertEquals(0, topInWindow(header()));
+        assertEquals(STATUS_BAR_INSET, topInWindow(expandedTitle()));
+        assertEquals(headerHeight(), header().getHeight() - STATUS_BAR_INSET);
+        assertPlaybackControlsAboveNavigationBar();
+    }
+
+    @Test
+    public void detailViewCollapsedMiniPlayerIsUnaffected() {
+        inflate(R.layout.activity_news_detail, SlidingUpPanelLayout.PanelState.COLLAPSED);
+
+        assertEquals(WINDOW_HEIGHT - NAVIGATION_BAR_INSET,
+                topInWindow(miniPlayerButton()) + miniPlayerButton().getHeight());
+        assertEquals(WINDOW_HEIGHT, topInWindow(header()) + header().getHeight());
+    }
+
+    @Test
+    public void detailViewExpandedPlayerIsUnchanged() {
+        inflate(R.layout.activity_news_detail, SlidingUpPanelLayout.PanelState.EXPANDED);
+
+        // the panel already starts below the status bar, so it must not be pushed down again
+        assertTrue("panel must not reach into the status bar",
+                topInWindow(slidingLayout) >= STATUS_BAR_INSET);
+        assertEquals(topInWindow(slidingLayout), topInWindow(expandedTitle()));
+        assertPlaybackControlsAboveNavigationBar();
+    }
+}


### PR DESCRIPTION
## Summary

Supersedes #1669, which fixed the bottom inset but left the expanded player drawn under the status bar. The first commit is @mvanhorn's original work, unchanged; the second one finishes the job.

The podcast panel spans the whole window in `activity_newsreader.xml`, so it has to keep clear of the system bars on its own. `activity_news_detail.xml` positions it below the toolbar already, which is why only the part of the status bar that is left over is added — that activity is unchanged.

## The rule

The header is the only part of the panel that is visible while it is collapsed, so it is the one touching the bottom of the screen then — and the top of it once the panel is expanded. It grows by the inset of that edge:

```java
boolean expanded = sliding_layout.getPanelState() == SlidingUpPanelLayout.PanelState.EXPANDED;
int top = expanded ? panelTopInset : 0;
int bottom = expanded ? 0 : panelBottomInset;

header.setPadding(0, top, 0, bottom);
header.getLayoutParams().height = getResources().getDimensionPixelSize(R.dimen.podcast_header_height) + top + bottom;
header.requestLayout();
```

This hooks into `onPanelStateChanged`, which already swaps the header's content, so the height change is hidden behind the existing cross-fade and there is no per-frame work while dragging.

Two things that took a detour before landing here, for the record:

- Resting the panel below the status bar via a top margin looks right in isolation, but the strip above it then exposes the main view, which `umanoParallaxOffset="100dp"` has dragged upward — a clipped toolbar with a feed row peeking through.
- Raising the collapsed panel height by the navigation bar inset without growing the header leaves the shadow divider and the top of the list area showing behind the navigation bar, over the panel's hardcoded white background.

## Changes

- `PodcastFragment` applies the inset of whichever screen edge the header touches.
- The panel background follows the header (`?attr/colorSecondaryContainer`) so the padded areas blend in, with the white background moved down onto `rlPodcast` so the list looks exactly as before.
- The header height moves to `@dimen/podcast_header_height`, since the collapsed panel height has to match it. That also makes `PodcastFragmentActivity.dipToPx()` dead code, so it is gone.

## Testing

`PodcastPanelInsetsTest` inflates both activity layouts together with `fragment_podcast.xml`, runs the real `SlidingUpPanelLayout` measure/layout pass at 1080x2400 with a 130px status bar and a 60px navigation bar, and asserts the resulting on-screen geometry — that the header's background reaches the screen edge, that the playback controls stay clear of the system bars, and that the detail view is left alone.

The assertions were checked against three variants to make sure they actually discriminate:

| Variant | Failing assertions |
| --- | --- |
| this PR | — |
| no top inset (#1669 as submitted) | expanded header behind the status bar |
| header does not carry the bottom inset | header background stops short of the screen edge, in both activities |
| panel rests below the status bar instead | expanded panel no longer covers the status bar |

Verified on device as well (Android 16, gesture navigation, dark theme), collapsed and expanded, in the feed view and the detail view. `assembleDevDebug` builds, 30 unit tests pass, lint reports nothing on the touched files.

Still ignored, as before this PR: horizontal insets, so a landscape navigation bar on the side.

Fixes #1647

🤖 Generated with [Claude Code](https://claude.com/claude-code)
