### PR TITLE
fix: toolbar and content are drawn under a side navigation bar

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
@@ -12,6 +12,7 @@ import android.support.v4.media.session.MediaControllerCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
 import android.util.Log;
 import android.util.TypedValue;
+import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
@@ -19,6 +20,8 @@ import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.FileProvider;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import com.nextcloud.android.sso.FilesAppTypeRegistry;
 import com.nextcloud.android.sso.helper.VersionCheckHelper;
@@ -91,7 +94,28 @@ public abstract class PodcastFragmentActivity extends AppCompatActivity implemen
 
         eventBus = EventBus.getDefault();
 
+        applyHorizontalInsets(findViewById(android.R.id.content));
         updatePodcastView();
+    }
+
+    /**
+     * Android 15+ enforces edge-to-edge, so the layout has to keep clear of the system bars on its
+     * own. The top and bottom insets are taken care of by the individual views, while the navigation
+     * bar ends up at the side of the screen in landscape, where nothing kept the toolbar and the
+     * content clear of it. Padding the content view moves the whole layout, the drawer and the
+     * podcast panel included, out of the way in a single place.
+     *
+     * <p>A display cutout is deliberately not taken into account. It is centered on the long edge of
+     * the screen, so in landscape it sits halfway down the side, far away from the toolbar - keeping
+     * clear of it would cost the width of the whole cutout without any element gaining from it.
+     */
+    @VisibleForTesting
+    public static void applyHorizontalInsets(View content) {
+        ViewCompat.setOnApplyWindowInsetsListener(content, (View v, WindowInsetsCompat insets) -> {
+            var bars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(bars.left, v.getPaddingTop(), bars.right, v.getPaddingBottom());
+            return insets;
+        });
     }
 
     @Override

--- a/News-Android-App/src/test/java/de/luhmer/owncloudnewsreader/junit_tests/HorizontalInsetsTest.java
+++ b/News-Android-App/src/test/java/de/luhmer/owncloudnewsreader/junit_tests/HorizontalInsetsTest.java
@@ -1,0 +1,123 @@
+package de.luhmer.owncloudnewsreader.junit_tests;
+
+import static org.junit.Assert.assertEquals;
+
+import android.app.Activity;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import de.luhmer.owncloudnewsreader.PodcastFragmentActivity;
+import de.luhmer.owncloudnewsreader.R;
+
+/**
+ * Verifies that the layouts keep clear of a navigation bar at the side of the screen, which is where
+ * it ends up in landscape with 3-button navigation, see
+ * <a href="https://github.com/nextcloud/news-android/issues/1679">#1679</a>.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(qualifiers = "w740dp-h360dp-land-xxhdpi")
+public class HorizontalInsetsTest {
+
+    private static final int WINDOW_WIDTH = 2220;
+    private static final int WINDOW_HEIGHT = 1080;
+    private static final int NAVIGATION_BAR_INSET = 130;
+    private static final int STATUS_BAR_INSET = 60;
+
+    private View content;
+
+    /**
+     * Builds the given activity layout below a stand in for {@code android.R.id.content} and applies
+     * the insets of a navigation bar on the left the way {@link PodcastFragmentActivity} does.
+     */
+    private void inflate(int activityLayout) {
+        Activity activity = Robolectric.buildActivity(Activity.class).setup().get();
+        activity.setTheme(R.style.AppTheme);
+
+        LayoutInflater inflater = LayoutInflater.from(activity);
+        // the <fragment> tags are of no interest here, but need a stand in to be inflatable
+        inflater.setFactory2(new LayoutInflater.Factory2() {
+            @Override
+            public View onCreateView(View parent, String name, Context context, AttributeSet attrs) {
+                return onCreateView(name, context, attrs);
+            }
+
+            @Override
+            public View onCreateView(String name, Context context, AttributeSet attrs) {
+                return "fragment".equals(name) ? new FrameLayout(context) : null;
+            }
+        });
+
+        content = new FrameLayout(activity);
+        ((FrameLayout) content).addView(inflater.inflate(activityLayout, null));
+
+        PodcastFragmentActivity.applyHorizontalInsets(content);
+        ViewCompat.dispatchApplyWindowInsets(content, new WindowInsetsCompat.Builder()
+                .setInsets(WindowInsetsCompat.Type.systemBars(),
+                        Insets.of(NAVIGATION_BAR_INSET, STATUS_BAR_INSET, 0, 0))
+                .build());
+
+        content.measure(
+                View.MeasureSpec.makeMeasureSpec(WINDOW_WIDTH, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(WINDOW_HEIGHT, View.MeasureSpec.EXACTLY));
+        content.layout(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
+    }
+
+    /** Position of the given view within the window. */
+    private int leftInWindow(View view) {
+        int left = 0;
+        for (View current = view; current != content; current = (View) current.getParent()) {
+            left += current.getLeft();
+        }
+        return left;
+    }
+
+    private void assertToolbarClearsTheNavigationBar() {
+        View toolbar = content.findViewById(R.id.toolbar);
+
+        // the navigation menu button sits at the very start of the toolbar
+        assertEquals(NAVIGATION_BAR_INSET, leftInWindow(toolbar));
+        assertEquals(WINDOW_WIDTH - NAVIGATION_BAR_INSET, toolbar.getWidth());
+    }
+
+    @Test
+    public void listViewToolbarClearsTheNavigationBar() {
+        inflate(R.layout.activity_newsreader);
+
+        assertToolbarClearsTheNavigationBar();
+    }
+
+    @Test
+    public void detailViewToolbarClearsTheNavigationBar() {
+        inflate(R.layout.activity_news_detail);
+
+        assertToolbarClearsTheNavigationBar();
+    }
+
+    @Test
+    public void slidingDrawerStartsBesideTheNavigationBar() {
+        inflate(R.layout.activity_newsreader);
+
+        assertEquals(NAVIGATION_BAR_INSET, leftInWindow(content.findViewById(R.id.drawer_layout)));
+    }
+
+    @Test
+    public void verticalInsetsAreLeftToTheViewsHandlingThem() {
+        inflate(R.layout.activity_newsreader);
+
+        assertEquals(0, content.getPaddingTop());
+        assertEquals(0, content.getPaddingBottom());
+    }
+}


### PR DESCRIPTION
Android 15+ enforces edge-to-edge, but the layouts only ever dealt with vertical insets: the CoordinatorLayout and the AppBarLayout apply the top inset via fitsSystemWindows, the sidebar and the podcast panel take care of the top and bottom ones themselves. Nothing consumed the horizontal insets, so in landscape with 3-button navigation the toolbar started at the very edge of the screen - underneath the navigation bar, which swallowed the taps on the navigation menu button.

The content view is padded by the horizontal insets now, which moves the whole layout - the drawer and the podcast panel included - out of the way in a single place, for both activities that show a toolbar. The vertical insets are left untouched, so the views handling those keep working.

A display cutout is deliberately left out of it: it is centered on the long edge of the screen, so in landscape it ends up halfway down the side, far away from the toolbar. Keeping clear of it would cost the width of the whole cutout without any element gaining from it.

Fixes #1679
