### PR TITLE
Target Android 16 (API level 36)

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/LoginDialogActivity.java
@@ -43,6 +43,7 @@ import android.util.Patterns;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -181,6 +182,8 @@ public class LoginDialogActivity extends AppCompatActivity {
         binding = ActivityLoginDialogBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        getOnBackPressedDispatcher().addCallback(this, onBackPressedCallback);
+
         binding.btnSingleSignOn.setOnClickListener((v) -> startSingleSignOn());
         binding.btnLogin.setOnClickListener((v) -> startManualLogin());
         binding.tvManualLogin.setOnClickListener((v) -> manualLogin());
@@ -205,16 +208,19 @@ public class LoginDialogActivity extends AppCompatActivity {
                 .commit());
     }
 
-    @Override
-    public void onBackPressed() {
-        if (mPrefs.getString(SettingsActivity.EDT_OWNCLOUDROOTPATH_STRING, null) == null) {
-            // exit application if no account is set uo
-            finishAffinity();
-        } else {
-            // go back to previous activity
-            super.onBackPressed();
+    private final OnBackPressedCallback onBackPressedCallback = new OnBackPressedCallback(true) {
+        @Override
+        public void handleOnBackPressed() {
+            if (mPrefs.getString(SettingsActivity.EDT_OWNCLOUDROOTPATH_STRING, null) == null) {
+                // exit application if no account is set up
+                finishAffinity();
+            } else {
+                // go back to previous activity
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+            }
         }
-    }
+    };
 
     private ProgressDialog buildPendingDialogWhileLoggingIn() {
         ProgressDialog pDialog = new ProgressDialog(this);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
@@ -41,6 +41,7 @@ import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -113,6 +114,8 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 
 		binding = ActivityNewsDetailBinding.inflate(getLayoutInflater());
 		setContentView(binding.getRoot());
+
+		getOnBackPressedDispatcher().addCallback(this, onBackPressedCallback);
 
 		/*
 		//make full transparent statusBar
@@ -438,11 +441,16 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 	}
 
 
-	@Override
-	public void onBackPressed() {
-		if (!handlePodcastBackPressed())
-			super.onBackPressed();
-	}
+	private final OnBackPressedCallback onBackPressedCallback = new OnBackPressedCallback(true) {
+		@Override
+		public void handleOnBackPressed() {
+			if (!handlePodcastBackPressed()) {
+				// nothing to collapse - fall back to the default back navigation
+				setEnabled(false);
+				getOnBackPressedDispatcher().onBackPressed();
+			}
+		}
+	};
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
@@ -497,7 +505,7 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 
 		final int itemId = item.getItemId();
 		if (itemId == android.R.id.home) {
-			onBackPressed();
+			getOnBackPressedDispatcher().onBackPressed();
 			return true;
 		} else if (itemId == R.id.action_read) {
 			this.markRead(currentPosition);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PiPVideoPlaybackActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PiPVideoPlaybackActivity.java
@@ -21,6 +21,7 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
 
 import org.greenrobot.eventbus.EventBus;
@@ -47,6 +48,8 @@ public class PiPVideoPlaybackActivity extends AppCompatActivity {
         ThemeChooser.afterOnCreate(this);
 
         setContentView(R.layout.activity_pip_video_playback);
+
+        getOnBackPressedDispatcher().addCallback(this, onBackPressedCallback);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) {
             //moveTaskToBack(false);
@@ -169,15 +172,18 @@ public class PiPVideoPlaybackActivity extends AppCompatActivity {
     */
 
 
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-
-        Log.d(TAG, "onBackPressed() called");
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            enterPictureInPictureMode();
+    private final OnBackPressedCallback onBackPressedCallback = new OnBackPressedCallback(true) {
+        @Override
+        public void handleOnBackPressed() {
+            Log.d(TAG, "handleOnBackPressed() called");
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                enterPictureInPictureMode();
+            } else {
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+            }
         }
-    }
+    };
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # org.gradle.parallel=true
 
 ANDROID_BUILD_MIN_SDK_VERSION=21
-ANDROID_BUILD_TARGET_SDK_VERSION=35
+ANDROID_BUILD_TARGET_SDK_VERSION=36
 ANDROID_BUILD_SDK_VERSION=36
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Bumps `targetSdk` from 35 to 36. `compileSdk` was already 36, so this is a behaviour-change audit rather than an SDK upgrade.

Google Play requires new app updates to target API 36 from **2026-08-31**.

## Behaviour changes reviewed

All 13 documented [targetSdk-36 behaviour changes](https://developer.android.com/about/versions/16/behavior-changes-16) were walked through:

| Change | Status |
|---|---|
| Predictive back enabled by default | **Fixed** — see below |
| Edge-to-edge opt-out disabled | Already fine — no `windowOptOutEdgeToEdgeEnforcement` anywhere, insets work landed in #1697 / #1698 |
| `elegantTextHeight` disabled | Not used |
| `scheduleAtFixedRate` skips missed runs | Benign — only use is the podcast progress ticker (`PodcastPlaybackService`), where skipping catch-up ticks is desirable |
| Orientation / resizability / aspect-ratio ignored on sw≥600dp | App code fine — no `screenOrientation` or `minAspectRatio` declared. Does affect the rotation UI test, which drives `setRequestedOrientation`; skipped on large screens in #1706 |
| `MediaStore.getVersion()` lockdown | Not used (only `MediaColumns` for OPML export) |
| Health permissions, Bluetooth bond intents, GPU syscall filtering, photo picker pre-selection | N/A |
| Safer intents, local network protection | Opt-in only — not enabled here, see below |

The APK ships **no native `.so` files**, so the 16 KB page-size requirement is satisfied for free.

## Changes

1. `ANDROID_BUILD_TARGET_SDK_VERSION` 35 → 36 in `gradle.properties`. Verified `targetSdkVersion="36"` in the merged manifest.
2. Migrated the three remaining `onBackPressed()` overrides — `LoginDialogActivity`, `NewsDetailActivity`, `PiPVideoPlaybackActivity` — to `OnBackPressedCallback`, reusing the pattern already in `NewsReaderListActivity`. `NewsDetailActivity`'s home-button handler now calls `getOnBackPressedDispatcher().onBackPressed()`.

## Notes for reviewers

**These three overrides were already dead code before this PR.** Since `android:enableOnBackInvokedCallback="true"` is set, AndroidX routes the system back callback through `OnBackPressedDispatcher`, whose fallback invokes `Activity.onBackPressed()` directly and therefore bypasses subclass overrides. So this fixes latent bugs rather than preventing new ones.

One **visible behaviour change**: back in `PiPVideoPlaybackActivity` now re-enters PiP (the original intent of the code) instead of just finishing the activity. Worth a manual check.

## Testing

`assembleOssDebug`, `lintOssDebug` and `testOssDebugUnitTest` all pass. **Not verified on-device** — the PiP-on-back change in particular deserves a manual check.

## Out of scope here

Two of the items originally listed here are now handled in #1706 (deprecated status bar flags, rotation UI test skip, and the analysis of why safer intents should *not* be enabled). #1705 fixes an unrelated podcast panel crash found while testing this branch.

**Local network permission** is the one remaining item with real user impact, and it needs nothing in this PR:

- SSO is exempt — it brokers credentials over AIDL/Binder, which local network protection does not cover. But SSO only carries the credentials: feed sync (Retrofit/OkHttp), Glide thumbnails, podcast and web page downloads all go out as ordinary TCP to the configured server URL, and manual login bypasses SSO entirely. So what matters is whether the user's Nextcloud is on their LAN — for a self-hosted app, often yes.
- Nothing to declare at SDK 36: local network access is open by default and only restricted behind an `adb shell am compat enable RESTRICT_LOCAL_NETWORK` opt-in. The docs explicitly say not to declare the permission below SDK 37.
- The failure mode when we do get there is unpleasant: blocked TCP surfaces as a **connection timeout**, not a clean rejection, so a user with a server at `192.168.1.x` would see the app hang and then report "sync is broken". Enforcement lives in the network stack, so OkHttp and Glide are equally affected, and there is no clean Java API to detect it (only `android_getnetworkblockedreason()` via NDK).
- Work needed at SDK 37: declare `ACCESS_LOCAL_NETWORK`, request it at runtime — ideally only when the configured URL looks local (RFC1918 / `.local` / bare IP) so ordinary hosted users never see a prompt — and add a specific error message on timeout. `NsdManager` with `FLAG_SHOW_PICKER` is the permission-free route but does not fit, since users type a URL rather than discovering a service.
