### PR TITLE
Fix crash when the podcast panel settles after the fragment detached

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
@@ -155,6 +155,19 @@ public class PodcastFragment extends Fragment {
         mActivity = null;
     }
 
+    @Override
+    public void onDestroyView() {
+        if (sliding_layout != null) {
+            // the panel belongs to the activity and outlives this fragment, so the listeners have to
+            // go - otherwise every updatePodcastView() stacks another one on top
+            sliding_layout.removePanelSlideListener(onPanelSlideListener);
+            ViewCompat.setOnApplyWindowInsetsListener(sliding_layout, null);
+            sliding_layout = null;
+        }
+
+        super.onDestroyView();
+    }
+
     protected void tryOpeningPictureinPictureMode() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             //moveTaskToBack(false /* nonRoot */);
@@ -228,6 +241,11 @@ public class PodcastFragment extends Fragment {
 
         @Override
         public void onPanelStateChanged(View panel, SlidingUpPanelLayout.PanelState previousState, SlidingUpPanelLayout.PanelState newState) {
+            if (sliding_layout == null || !isAdded()) {
+                // a settling panel still notifies the listeners it captured before it got removed
+                return;
+            }
+
             if (newState == SlidingUpPanelLayout.PanelState.COLLAPSED) {
                 sliding_layout.setDragView(binding.llPodcastHeader);
                 binding.viewSwitcherProgress.setDisplayedChild(0);
@@ -324,6 +342,12 @@ public class PodcastFragment extends Fragment {
      * the playback controls stay clear of it.
      */
     private void applyPodcastHeaderInsets() {
+        if (sliding_layout == null || !isAdded()) {
+            // the panel can settle after the fragment got detached, e.g. when a sync finishes while
+            // the user is dragging it - there is nothing left to lay out in that case
+            return;
+        }
+
         boolean expanded = sliding_layout.getPanelState() == SlidingUpPanelLayout.PanelState.EXPANDED;
         int top = expanded ? panelTopInset : 0;
         int bottom = expanded ? 0 : panelBottomInset;


### PR DESCRIPTION
## The crash

```
java.lang.IllegalStateException: Fragment PodcastFragment{d6b3735} not attached to a context.
    at androidx.fragment.app.Fragment.requireContext(Fragment.java:977)
    at androidx.fragment.app.Fragment.getResources(Fragment.java:1041)
    at de.luhmer.owncloudnewsreader.PodcastFragment.applyPodcastHeaderInsets(PodcastFragment.java:333)
    at de.luhmer.owncloudnewsreader.PodcastFragment$1.onPanelStateChanged(PodcastFragment.java:234)
    at com.sothree.slidinguppanel.SlidingUpPanelLayout.dispatchOnPanelStateChanged
    ...
    at com.sothree.slidinguppanel.ViewDragHelper$2.run
```

Reproduced by starting a podcast and swiping the panel up.

## Cause

`PodcastFragment.onCreateView()` registers an `onPanelSlideListener` and an
`OnApplyWindowInsetsListener` on the `SlidingUpPanelLayout` returned by
`PodcastFragmentActivity.getSlidingLayout()`. That panel is owned by the **activity** and
outlives the fragment's view, but neither listener was ever removed —
`removePanelSlideListener` does not appear anywhere in the codebase.

The fragment's view gets destroyed and recreated on **activity recreation** (rotation, theme
change, any config change that is not handled). `mPodcastFragment` is a plain field, so the
recreated activity sees it as `null` and `updatePodcastView()` builds a *new* `PodcastFragment`,
while the `FragmentManager` has already restored the previous instance into `R.id.podcast_frame`.
The `replace()` removes that restored instance — and because reordering is not enabled, the new
instance reaches `onCreateView()` *before* the old one is torn down, so for a moment both
instances hold a listener on the same panel (the backing list is a `CopyOnWriteArrayList`, so
they coexist rather than replace each other).

`ViewDragHelper` posts the settle callback and `dispatchOnPanelStateChanged` iterates the
listener snapshot, so a callback that is still in flight while the outgoing instance is being
destroyed reaches `getResources()` → `requireContext()` on a fragment that no longer has a host
→ crash.

Note that the `updatePodcastView()` call from `syncFinishedHandler()` is *not* part of this: it
passes the same `mPodcastFragment` instance that is already added to that container, and
`BackStackRecord.expandOps()` drops such a `replace` op entirely. A finished sync therefore
neither recreates the view nor stacks a second listener.

## Fix

- Remove both listeners in a new `onDestroyView()` and drop the `sliding_layout` reference.
- Bail out of `onPanelStateChanged` and `applyPodcastHeaderInsets` while the fragment is
  detached, since a settling panel still notifies the listeners it captured before removal.

## Notes

Introduced in 690f7e8a ("fix: podcast player is drawn under the system bars"), which added
`applyPodcastHeaderInsets`. Besides the crash this also fixes a listener leak — one listener per
activity recreation, for as long as the activity lives.

`binding` is deliberately **not** nulled in `onDestroyView` — the `DownloadProgressUpdate`
EventBus handler still dereferences it, so clearing it would trade this crash for an NPE. That is
a pre-existing issue and left alone here.

## Testing

`assembleDevDebug` and `lintOssDebug` pass. **Not verified on-device** — the race needs the panel
settling while the fragment is being torn down, so please confirm the original repro is gone.
