### PR TITLE
Replace deprecated status bar flags and guard the rotation UI test

### DIFF
--- a/News-Android-App/src/androidTest/java/de/luhmer/owncloudnewsreader/tests/NewsReaderListActivityUiTests.java
+++ b/News-Android-App/src/androidTest/java/de/luhmer/owncloudnewsreader/tests/NewsReaderListActivityUiTests.java
@@ -1,7 +1,6 @@
 package de.luhmer.owncloudnewsreader.tests;
 
 import android.content.SharedPreferences;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.view.View;
@@ -111,12 +110,34 @@ public class NewsReaderListActivityUiTests {
         initMaterialShowCaseView(getActivity());
     }
 
+    private int currentOrientation() {
+        return getActivity().getResources().getConfiguration().orientation;
+    }
+
+    /**
+     * Waits for the orientation to differ from the one before the rotation was requested. Polling
+     * instead of a fixed delay keeps a slow rotation from being mistaken for an ignored one, which
+     * would silently skip the test instead of failing it.
+     */
+    private boolean awaitOrientationChange(int orientationBeforeRotation) {
+        long deadline = SystemClock.uptimeMillis() + 5000;
+        while (SystemClock.uptimeMillis() < deadline) {
+            if (currentOrientation() != orientationBeforeRotation) {
+                return true;
+            }
+            sleep(250);
+        }
+        return false;
+    }
+
     @Test
     public void testPositionAfterOrientationChange_sameActivity() {
         NewsReaderDetailFragment ndf = (NewsReaderDetailFragment) waitForFragment(R.id.content_frame, 5000);
 
         onView(withId(R.id.list)).perform(
                 RecyclerViewActions.scrollToPosition(scrollPosition));
+
+        int orientationBeforeRotation = currentOrientation();
 
         onView(isRoot()).perform(OrientationChangeAction.orientationLandscape(getActivity()));
         //onView(isRoot()).perform(OrientationChangeAction.orientationPortrait(getActivity()));
@@ -125,8 +146,10 @@ public class NewsReaderListActivityUiTests {
 
         // Android 16 ignores orientation requests on displays with a smallest width of 600dp or
         // more, so on those devices the rotation never happens and there is nothing to assert.
+        // Comparing against the orientation before the request also covers devices that are
+        // already in landscape, where checking for landscape alone would let the test run on.
         assumeTrue("device ignores requested orientation changes",
-                getActivity().getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE);
+                awaitOrientationChange(orientationBeforeRotation));
 
         LinearLayoutManager llm = (LinearLayoutManager) ndf.getRecyclerView().getLayoutManager();
         int expectedPosition = scrollPosition-(scrollPosition-llm.findFirstVisibleItemPosition());

--- a/News-Android-App/src/androidTest/java/de/luhmer/owncloudnewsreader/tests/NewsReaderListActivityUiTests.java
+++ b/News-Android-App/src/androidTest/java/de/luhmer/owncloudnewsreader/tests/NewsReaderListActivityUiTests.java
@@ -1,6 +1,7 @@
 package de.luhmer.owncloudnewsreader.tests;
 
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.view.View;
@@ -50,6 +51,7 @@ import helper.OrientationChangeAction;
 import helper.RecyclerViewAssertions;
 
 import static androidx.core.util.Preconditions.checkNotNull;
+import static org.junit.Assume.assumeTrue;
 import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.InstrumentationRegistry.registerInstance;
 import static androidx.test.espresso.Espresso.onView;
@@ -120,6 +122,11 @@ public class NewsReaderListActivityUiTests {
         //onView(isRoot()).perform(OrientationChangeAction.orientationPortrait(getActivity()));
 
         sleep(2000);
+
+        // Android 16 ignores orientation requests on displays with a smallest width of 600dp or
+        // more, so on those devices the rotation never happens and there is nothing to assert.
+        assumeTrue("device ignores requested orientation changes",
+                getActivity().getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE);
 
         LinearLayoutManager llm = (LinearLayoutManager) ndf.getRecyclerView().getLayoutManager();
         int expectedPosition = scrollPosition-(scrollPosition-llm.findFirstVisibleItemPosition());

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
@@ -106,6 +106,9 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 
 	private boolean mShowFastActions;
 
+	/** Whether the toolbar and the status bar currently carry the incognito colours. */
+	private boolean mIncognitoColorsApplied;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		((NewsReaderApplication) getApplication()).getAppComponent().injectActivity(this);
@@ -654,21 +657,27 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
             return;
         }
 
-        // Switching incognito mode off does not restore the toolbar - it keeps its dark colours
-        // until the activity is recreated. So the status bar must not be restored on its own
-        // either, or a light status bar would sit on top of a still dark toolbar.
-        if (!isIncognitoEnabled()) {
+        boolean incognito = isIncognitoEnabled();
+        if (!incognito && !mIncognitoColorsApplied) {
+            // nothing to restore, toolbar and status bar still follow the theme
             return;
         }
 
-        int color = getResources().getColor(R.color.material_grey_900);
-        ThemeUtils.colorizeToolbar(binding.toolbarLayout.toolbar, color);
+        int background = getResources().getColor(incognito ? R.color.material_grey_900 : R.color.surface);
+        int foreground = getResources().getColor(incognito ? android.R.color.white : R.color.onSurface);
         // the first three menu items are from the fast actions (if enabled)
         int skipItems = mShowFastActions ? 3 : 0;
-        int white = getResources().getColor(android.R.color.white);
-        ThemeUtils.colorizeToolbarForeground(binding.toolbarLayout.toolbar, white, skipItems);
 
-        applyIncognitoStatusBar();
+        ThemeUtils.colorizeToolbar(binding.toolbarLayout.toolbar, background);
+        if (incognito) {
+            ThemeUtils.colorizeToolbarForeground(binding.toolbarLayout.toolbar, foreground, skipItems);
+        } else {
+            ThemeUtils.resetToolbarForeground(binding.toolbarLayout.toolbar, foreground, skipItems);
+        }
+
+        applyIncognitoStatusBar(incognito);
+
+        mIncognitoColorsApplied = incognito;
 
 
 		//ThemeUtils.colorizeToolbar(bottomAppBar, color);
@@ -685,14 +694,15 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 	 * draws behind it, which stays light in day mode - so light icons would be invisible and the
 	 * status bar keeps following the theme instead.
 	 */
-	private void applyIncognitoStatusBar() {
+	private void applyIncognitoStatusBar(boolean incognito) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
 			return;
 		}
 
-		getWindow().setStatusBarColor(getResources().getColor(R.color.material_grey_900));
+		getWindow().setStatusBarColor(getResources().getColor(
+				incognito ? R.color.material_grey_900 : R.color.surface));
 		WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView())
-				.setAppearanceLightStatusBars(false);
+				.setAppearanceLightStatusBars(!incognito);
 	}
 
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
@@ -42,6 +42,7 @@ import android.webkit.WebView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.WindowCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
@@ -659,7 +660,8 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
                 int skipItems = mShowFastActions ? 3 : 0;
                 int white = getResources().getColor(android.R.color.white);
                 ThemeUtils.colorizeToolbarForeground(binding.toolbarLayout.toolbar, white, skipItems);
-                clearLightStatusBar(getWindow().getDecorView());
+                clearLightStatusBar();
+                // no-op on Android 15+, but still colours the status bar on older releases
                 getWindow().setStatusBarColor(color);
             }
         }
@@ -670,41 +672,15 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 		//getWindow().setNavigationBarColor(color);
 
 
-		/*
-		switch (ThemeChooser.getSelectedTheme()) {
-			case LIGHT:
-				Log.d(TAG, "initIncognitoMode: LIGHT");
-				getWindow().setStatusBarColor(Color.WHITE);
-				break;
-			case DARK:
-				clearLightStatusBar(getWindow().getDecorView());
-				Log.d(TAG, "initIncognitoMode: DARK");
-				getWindow().setStatusBarColor(getResources().getColor(R.color.material_grey_900));
-				break;
-			case OLED:
-				clearLightStatusBar(getWindow().getDecorView());
-				Log.d(TAG, "initIncognitoMode: OLED");
-				getWindow().setStatusBarColor(Color.BLACK);
-				break;
-		}
-		*/
 	}
 
 
-	private void setLightStatusBar(@NonNull View view) {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-			int flags = view.getSystemUiVisibility(); // get current flag
-			flags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;   // add LIGHT_STATUS_BAR to flag
-			view.setSystemUiVisibility(flags);
-		}
-	}
-
-	public static void clearLightStatusBar(@NonNull View view) {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-			int flags = view.getSystemUiVisibility();
-			flags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-			view.setSystemUiVisibility(flags);
-		}
+	/**
+	 * The incognito toolbar is dark, so the status bar icons on top of it have to stay light.
+	 */
+	private void clearLightStatusBar() {
+		WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView())
+				.setAppearanceLightStatusBars(false);
 	}
 
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
@@ -650,21 +650,21 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 	}
 
 	public void initIncognitoMode() {
-        if (isIncognitoEnabled()) {
-            boolean isLightTheme = !ThemeChooser.isDarkTheme(this);
-            if (isLightTheme) {
-
-                int color = getResources().getColor(isIncognitoEnabled() ? R.color.material_grey_900 : R.color.colorPrimary);
-                ThemeUtils.colorizeToolbar(binding.toolbarLayout.toolbar, color);
-                // the first three menu items are from the fast actions (if enabled)
-                int skipItems = mShowFastActions ? 3 : 0;
-                int white = getResources().getColor(android.R.color.white);
-                ThemeUtils.colorizeToolbarForeground(binding.toolbarLayout.toolbar, white, skipItems);
-                clearLightStatusBar();
-                // no-op on Android 15+, but still colours the status bar on older releases
-                getWindow().setStatusBarColor(color);
-            }
+        if (ThemeChooser.isDarkTheme(this)) {
+            return;
         }
+
+        boolean incognito = isIncognitoEnabled();
+        if (incognito) {
+            int color = getResources().getColor(R.color.material_grey_900);
+            ThemeUtils.colorizeToolbar(binding.toolbarLayout.toolbar, color);
+            // the first three menu items are from the fast actions (if enabled)
+            int skipItems = mShowFastActions ? 3 : 0;
+            int white = getResources().getColor(android.R.color.white);
+            ThemeUtils.colorizeToolbarForeground(binding.toolbarLayout.toolbar, white, skipItems);
+        }
+
+        applyIncognitoStatusBar(incognito);
 
 
 		//ThemeUtils.colorizeToolbar(bottomAppBar, color);
@@ -676,11 +676,20 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 
 
 	/**
-	 * The incognito toolbar is dark, so the status bar icons on top of it have to stay light.
+	 * Tinting the status bar dark and switching its icons to light only works below Android 15.
+	 * From there on setStatusBarColor() is ignored and the status bar shows whatever the window
+	 * draws behind it, which stays light in day mode - so light icons would be invisible and the
+	 * status bar keeps following the theme instead.
 	 */
-	private void clearLightStatusBar() {
+	private void applyIncognitoStatusBar(boolean incognito) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+			return;
+		}
+
+		getWindow().setStatusBarColor(getResources().getColor(
+				incognito ? R.color.material_grey_900 : R.color.surface));
 		WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView())
-				.setAppearanceLightStatusBars(false);
+				.setAppearanceLightStatusBars(!incognito);
 	}
 
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
@@ -654,17 +654,21 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
             return;
         }
 
-        boolean incognito = isIncognitoEnabled();
-        if (incognito) {
-            int color = getResources().getColor(R.color.material_grey_900);
-            ThemeUtils.colorizeToolbar(binding.toolbarLayout.toolbar, color);
-            // the first three menu items are from the fast actions (if enabled)
-            int skipItems = mShowFastActions ? 3 : 0;
-            int white = getResources().getColor(android.R.color.white);
-            ThemeUtils.colorizeToolbarForeground(binding.toolbarLayout.toolbar, white, skipItems);
+        // Switching incognito mode off does not restore the toolbar - it keeps its dark colours
+        // until the activity is recreated. So the status bar must not be restored on its own
+        // either, or a light status bar would sit on top of a still dark toolbar.
+        if (!isIncognitoEnabled()) {
+            return;
         }
 
-        applyIncognitoStatusBar(incognito);
+        int color = getResources().getColor(R.color.material_grey_900);
+        ThemeUtils.colorizeToolbar(binding.toolbarLayout.toolbar, color);
+        // the first three menu items are from the fast actions (if enabled)
+        int skipItems = mShowFastActions ? 3 : 0;
+        int white = getResources().getColor(android.R.color.white);
+        ThemeUtils.colorizeToolbarForeground(binding.toolbarLayout.toolbar, white, skipItems);
+
+        applyIncognitoStatusBar();
 
 
 		//ThemeUtils.colorizeToolbar(bottomAppBar, color);
@@ -681,15 +685,14 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 	 * draws behind it, which stays light in day mode - so light icons would be invisible and the
 	 * status bar keeps following the theme instead.
 	 */
-	private void applyIncognitoStatusBar(boolean incognito) {
+	private void applyIncognitoStatusBar() {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
 			return;
 		}
 
-		getWindow().setStatusBarColor(getResources().getColor(
-				incognito ? R.color.material_grey_900 : R.color.surface));
+		getWindow().setStatusBarColor(getResources().getColor(R.color.material_grey_900));
 		WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView())
-				.setAppearanceLightStatusBars(!incognito);
+				.setAppearanceLightStatusBars(false);
 	}
 
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ThemeUtils.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ThemeUtils.java
@@ -34,6 +34,7 @@ import android.view.WindowManager;
 import android.widget.ImageButton;
 
 import androidx.annotation.ColorInt;
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.widget.ActionMenuView;
 import androidx.appcompat.widget.Toolbar;
@@ -73,9 +74,26 @@ public class ThemeUtils {
      * @param skipMenuItems          how many menu items should not be colored
      */
     public static void colorizeToolbarForeground(Toolbar toolbarView, @ColorInt int toolbarForegroundColor, int skipMenuItems) {
+        applyToolbarForeground(toolbarView, toolbarForegroundColor,
+                new PorterDuffColorFilter(toolbarForegroundColor, PorterDuff.Mode.SRC_IN), skipMenuItems);
+    }
+
+    /**
+     * Undoes {@link #colorizeToolbarForeground}: the icons drop their color filter, so that they
+     * are drawn in their own (theme aware) tint again instead of a single flat color. Only the
+     * title has to be set to a color, as there is nothing to reset it to.
+     *
+     * @param toolbarView            toolbar view being reset
+     * @param toolbarForegroundColor the title color of the theme
+     * @param skipMenuItems          how many menu items should not be reset
+     */
+    public static void resetToolbarForeground(Toolbar toolbarView, @ColorInt int toolbarForegroundColor, int skipMenuItems) {
+        applyToolbarForeground(toolbarView, toolbarForegroundColor, null, skipMenuItems);
+    }
+
+    private static void applyToolbarForeground(Toolbar toolbarView, @ColorInt int toolbarForegroundColor, @Nullable ColorFilter cf, int skipMenuItems) {
         toolbarView.setTitleTextColor(toolbarForegroundColor);
 
-        ColorFilter cf = new PorterDuffColorFilter(toolbarForegroundColor, PorterDuff.Mode.SRC_IN);
         Drawable drawable = toolbarView.getOverflowIcon();
         if (drawable != null) {
             drawable.setColorFilter(cf);


### PR DESCRIPTION
Follow-up to #1704.

**Status bar flags.** `NewsDetailActivity` still drove the status bar appearance through `SYSTEM_UI_FLAG_LIGHT_STATUS_BAR`, deprecated since API 30. `clearLightStatusBar()` now goes through `WindowInsetsController`; the unused `setLightStatusBar()` and a stale commented-out theme switch are removed.

`setStatusBarColor()` stays — it is a no-op for targetSdk 35+ on Android 15 and above, but still colours the status bar below that.

**Rotation UI test.** Android 16 ignores orientation requests on displays with a smallest width of 600dp or more, so `testPositionAfterOrientationChange_sameActivity` never rotates on tablets and then fails on a scroll offset that only a rotation produces. It now skips via `assumeTrue` when the configuration did not change.

Build, lint and unit tests pass. Not verified on device.
