### PR TITLE
fix: podcast panel loses its window insets after an activity recreation

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragment.java
@@ -158,10 +158,10 @@ public class PodcastFragment extends Fragment {
     @Override
     public void onDestroyView() {
         if (sliding_layout != null) {
-            // the panel belongs to the activity and outlives this fragment, so the listeners have to
-            // go - otherwise every updatePodcastView() stacks another one on top
+            // the panel belongs to the activity and outlives this fragment, so the listener has to go
+            // - otherwise every activity recreation leaves another one behind on the panel. The insets
+            // listener is left in place on purpose, see applyPodcastInsets().
             sliding_layout.removePanelSlideListener(onPanelSlideListener);
-            ViewCompat.setOnApplyWindowInsetsListener(sliding_layout, null);
             sliding_layout = null;
         }
 
@@ -309,6 +309,12 @@ public class PodcastFragment extends Fragment {
      * The panel spans the whole window in {@link NewsReaderListActivity}, so it has to keep clear of
      * the system bars on its own. {@link NewsDetailActivity} positions it below the toolbar already,
      * which is why only the part of the status bar that is left over is taken into account.
+     *
+     * <p>The listener is not removed in {@link #onDestroyView()}. It belongs to the activity's panel,
+     * and a replacement fragment reaches {@link #onCreateView} before the outgoing one is torn down -
+     * clearing it there would wipe the listener the new fragment has just installed, and the insets
+     * would never reach the panel again. Installing it here overwrites whatever the previous fragment
+     * left behind, which is all the cleanup that is needed.
      */
     private void applyPodcastInsets() {
         final View root = binding.getRoot();


### PR DESCRIPTION
Follow-up to #1705: `onDestroyView()` also cleared the panel's `OnApplyWindowInsetsListener`, but that one is not per-fragment state and reordering is not enabled here, so the replacement fragment installs its own listener in `onCreateView()` *before* the outgoing fragment nulls it again. The insets traversal queued by `requestApplyInsets()` then runs without a listener, so after every activity recreation with the panel showing the collapsed header ends up under the navigation bar again. Dropping that one line is enough — `applyPodcastInsets()` already overwrites whatever the previous fragment left behind. The comment in `onDestroyView()` was also wrong: `updatePodcastView()` from a finished sync passes the already-added instance and `BackStackRecord.expandOps()` drops that `replace` op, so syncs never stacked listeners; only activity recreation did. `compileDevDebugJavaWithJavac` passes, but this is **not verified on-device** — please check the collapsed header after rotating with a podcast playing.
