### PR TITLE
Fix back not collapsing the podcast panel after a resume

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -218,9 +218,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 		@Override
 		public void onPanelStateChanged(View panel, SlidingUpPanelLayout.PanelState previousState, SlidingUpPanelLayout.PanelState newState) {
-			boolean panelIsOpen = newState.equals(SlidingUpPanelLayout.PanelState.EXPANDED);
-			// in case the podcast panel is open, we need to close it first (intercept back presses)
-			onBackPressedCallback.setEnabled(panelIsOpen || mBackOpensDrawer);
+			updateBackPressedCallbackState();
 		}
 	};
 
@@ -244,6 +242,18 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 			}
 		}
 	};
+
+	/**
+	 * Back navigation has to be intercepted while the podcast panel is expanded, so that it collapses
+	 * the panel instead of leaving the activity - regardless of the "Open Sidebar on Backpress"
+	 * setting. The panel state is read back here rather than tracked, because this is also called
+	 * from onResume(), where the panel may already have been expanded before.
+	 */
+	private void updateBackPressedCallbackState() {
+		boolean panelIsOpen = SlidingUpPanelLayout.PanelState.EXPANDED
+				.equals(getPodcastSlidingUpPanelLayout().getPanelState());
+		onBackPressedCallback.setEnabled(panelIsOpen || mBackOpensDrawer);
+	}
 
     protected DisposableObserver<Boolean> startSyncObserver = new DisposableObserver<>() {
         @Override
@@ -541,7 +551,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 				@Override
 				public void onDrawerClosed(View drawerView) {
 					super.onDrawerClosed(drawerView);
-					onBackPressedCallback.setEnabled(mBackOpensDrawer);
+					updateBackPressedCallbackState();
 
 					syncState();
 				}
@@ -590,7 +600,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 	@Override
 	protected void onResume() {
 		mBackOpensDrawer = mPrefs.getBoolean(SettingsActivity.CB_PREF_BACK_OPENS_DRAWER, false);
-		onBackPressedCallback.setEnabled(mBackOpensDrawer);
+		updateBackPressedCallbackState();
 
 		reloadSidebar();
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -256,7 +256,6 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 		boolean canOpenDrawer = mBackOpensDrawer && binding.drawerLayout != null;
 		onBackPressedCallback.setEnabled(panelIsOpen || canOpenDrawer);
 	}
-	}
 
     protected DisposableObserver<Boolean> startSyncObserver = new DisposableObserver<>() {
         @Override

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -252,7 +252,10 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 	private void updateBackPressedCallbackState() {
 		boolean panelIsOpen = SlidingUpPanelLayout.PanelState.EXPANDED
 				.equals(getPodcastSlidingUpPanelLayout().getPanelState());
-		onBackPressedCallback.setEnabled(panelIsOpen || mBackOpensDrawer);
+		// the drawer is absent in the tablet landscape layout, so back must not try to open it
+		boolean canOpenDrawer = mBackOpensDrawer && binding.drawerLayout != null;
+		onBackPressedCallback.setEnabled(panelIsOpen || canOpenDrawer);
+	}
 	}
 
     protected DisposableObserver<Boolean> startSyncObserver = new DisposableObserver<>() {


### PR DESCRIPTION
`NewsReaderListActivity` enables its `OnBackPressedCallback` from two different rules: `onPanelStateChanged()` used `panelIsOpen || mBackOpensDrawer`, while `onResume()` and `onDrawerClosed()` used `mBackOpensDrawer` alone.

With "Open Sidebar on Backpress" off — the default, the preference has no `android:defaultValue` — resuming with the podcast panel expanded disables the callback. The panel emits no state change on resume, so nothing re-enables it and back leaves the activity instead of collapsing the panel.

All three sites now go through `updateBackPressedCallbackState()`, which reads the current panel state rather than relying on a transition.

## Testing

Verified on a Pixel 9 Pro (Android 17, dev build):

- callback invoked when the preference is on, not invoked when it is off — the wiring was never the problem
- background/resume cycle exercises the new `onResume` path without a crash
- back with the preference off and the panel closed still leaves the activity

The panel-expanded-across-resume case itself needs a podcast playing and was not automated.