### PR TITLE
Update glide to 5.0.9 / switch to imagedecoder

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -115,7 +115,7 @@ repositories {
 }
 
 final DAGGER_VERSION = '2.59.2'
-final GLIDE_VERSION = '5.0.7'
+final GLIDE_VERSION = '5.0.9'
 final ESPRESSO_VERSION = '3.7.0'
 final OKHTTP_VERSION = '5.3.2'
 final MOCKITO_VERSION = '5.23.0'

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/NextcloudGlideModule.kt
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/NextcloudGlideModule.kt
@@ -46,6 +46,13 @@ class NextcloudGlideModule : AppGlideModule() {
         builder.setDiskCache(InternalCacheDiskCacheFactory(context, diskCacheSizeBytes.toLong()))
         // builder.setDiskCache(ExternalPreferredCacheDiskCacheFactory(context))
 
+        // Decode bitmaps through Android's ImageDecoder (API 29+) instead of BitmapFactory.
+        // It is the platform's preferred decoder and usually needs less memory. Glide falls back
+        // to BitmapFactory on older releases on its own, so no version check is needed here.
+        builder.setImageDecoderEnabledForBitmaps(true)
+        // Let ImageDecoder read local Uris directly instead of going through an InputStream.
+        builder.setUriImageDecoderEnabled(true)
+
         // #00ff00 Memory Cache (Green)
         // #0066ff Disk Cache (Blue)
         // #ff0000 Remote (Red)

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-ANDROID_BUILD_MIN_SDK_VERSION=21
+ANDROID_BUILD_MIN_SDK_VERSION=23
 ANDROID_BUILD_TARGET_SDK_VERSION=36
 ANDROID_BUILD_SDK_VERSION=36
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 ANDROID_BUILD_MIN_SDK_VERSION=23
 ANDROID_BUILD_TARGET_SDK_VERSION=36
-ANDROID_BUILD_SDK_VERSION=36
+ANDROID_BUILD_SDK_VERSION=37
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.dependency.verification.console=verbose
@@ -34,3 +34,4 @@ android.r8.strictFullModeForKeepRules=true
 android.r8.optimizedResourceShrinking=true
 android.builtInKotlin=true
 android.newDsl=true
+android.suppressUnsupportedCompileSdk=37.0


### PR DESCRIPTION
superseeds https://github.com/nextcloud/news-android/pull/1703


Side effect.. we'd have to drop API level 21... (upgrade to 23)